### PR TITLE
feat(map): add map_timeout config for longer MAP operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to the AxonFlow Java SDK will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- **MAP Endpoint** - Fixed `generatePlan()` to use correct Agent API endpoint
+  - Changed from `/api/v1/orchestrator/plan` to `/api/request` with `request_type: "multi-agent-plan"`
+  - Added proper response parsing for Agent API format
+  - Fixed null-safety issues with request context
+
+## [1.1.0] - 2025-12-19
+
+### Added
+
+- **LLM Interceptors** - Transparent governance for LLM API calls (#1)
+  - `OpenAIInterceptor` for OpenAI API interception
+  - `AnthropicInterceptor` for Anthropic API interception
+  - `GeminiInterceptor` for Google Generative AI interception
+  - Policy enforcement and audit logging for all providers
+- Full feature parity with other SDKs for LLM interceptors
+- **Self-Hosted Zero-Config Tests** - Auth header verification for localhost (#2)
+  - Tests verify auth headers are skipped for localhost endpoints
+
+## [1.0.0] - 2025-12-04
+
+### Added
+
+- Initial release of AxonFlow Java SDK
+- Core client with `executeQuery()` for governed AI calls
+- Policy enforcement with `PolicyViolationException`
+- **Gateway Mode** support
+  - `getPolicyApprovedContext()` for pre-checks
+  - `auditLLMCall()` for compliance logging
+- **Multi-Agent Planning**
+  - `generatePlan()` for creating execution plans
+  - `executePlan()` for running plans
+  - `getPlanStatus()` for checking plan status
+- **MCP Connectors**
+  - `listConnectors()` for available connectors
+  - `installConnector()` for connector installation
+  - `queryConnector()` for connector queries
+- Comprehensive type definitions with Jackson
+- Retry logic with exponential backoff (OkHttp)
+- Response caching with Caffeine
+- Self-hosted mode for localhost deployments
+- Java 11+ compatibility
+- Maven Central publishing support

--- a/src/test/java/com/getaxonflow/sdk/AxonFlowTest.java
+++ b/src/test/java/com/getaxonflow/sdk/AxonFlowTest.java
@@ -229,11 +229,12 @@ class AxonFlowTest {
     @Test
     @DisplayName("generatePlanAsync should return future")
     void generatePlanAsyncShouldReturnFuture() throws Exception {
-        stubFor(post(urlEqualTo("/api/v1/orchestrator/plan"))
+        // Now uses Agent API endpoint with request_type: multi-agent-plan
+        stubFor(post(urlEqualTo("/api/request"))
             .willReturn(aResponse()
                 .withStatus(200)
                 .withHeader("Content-Type", "application/json")
-                .withBody("{\"plan_id\":\"plan_123\",\"steps\":[]}")));
+                .withBody("{\"success\":true,\"plan_id\":\"plan_123\",\"data\":{\"steps\":[]}}")));
 
         PlanRequest request = PlanRequest.builder()
             .objective("test")


### PR DESCRIPTION
## Summary
- Add `map_timeout` parameter to AxonFlowConfig (default: 120s)
- Create separate `_map_http_client` with longer timeout for MAP operations
- Update `generate_plan()` and `execute_plan()` to use the longer MAP timeout

## Why
MAP (Multi-Agent Planning) operations involve multiple LLM calls and can take 30-60+ seconds. The default 60s timeout causes timeouts for complex queries.

## Test plan
- [x] All 203 unit tests pass
- [x] MAP example tested successfully against staging

## CHANGELOG
Updated with [Unreleased] section.