### PR TITLE
fix: use Collectors.toList() for Java 11 compatibility

### DIFF
--- a/src/main/java/com/getaxonflow/sdk/AxonFlow.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlow.java
@@ -438,7 +438,7 @@ public final class AxonFlow implements Closeable {
             if (rawSteps != null) {
                 steps = rawSteps.stream()
                     .map(stepMap -> objectMapper.convertValue(stepMap, PlanStep.class))
-                    .toList();
+                    .collect(java.util.stream.Collectors.toList());
             }
             domain = data.get("domain") != null ? (String) data.get("domain") : domain;
             complexity = data.get("complexity") != null ? ((Number) data.get("complexity")).intValue() : null;


### PR DESCRIPTION
## Summary
- Fix compilation failure on Java 11: `cannot find symbol: method toList()`
- `Stream.toList()` was introduced in Java 16, but SDK targets Java 11

## Changes
- Replace `.toList()` with `.collect(Collectors.toList())` in `AxonFlow.java`

## Test plan
- [ ] Build should pass on Java 11, 17, and 21