### PR TITLE
fix(ci): add contents:write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Fix release workflow failing with 403 (Forbidden) when creating GitHub releases.

## Root Cause
The release workflow was missing the `permissions: contents: write` block which is required for the `softprops/action-gh-release` action to create releases.

## Evidence
- Go SDK workflow has this permission: `.github/workflows/release.yml:8-9`
- Python SDK workflow has this permission: `.github/workflows/release.yml:41,58`
- Java SDK was missing it

## Error (from v1.1.2 release attempt)
```
👩‍🏭 Creating new GitHub release for tag v1.1.2...
⚠️ GitHub release failed with status: 403
```

## Fix
Added `permissions: contents: write` to the workflow file.