### PR TITLE
feat(types): add require_approval action for HITL workflows

### DIFF
--- a/src/main/java/com/getaxonflow/sdk/types/policies/PolicyTypes.java
+++ b/src/main/java/com/getaxonflow/sdk/types/policies/PolicyTypes.java
@@ -84,12 +84,20 @@ public final class PolicyTypes {
 
     /**
      * Override action for policy overrides.
+     * <ul>
+     *   <li>BLOCK: Immediately block the request</li>
+     *   <li>REQUIRE_APPROVAL: Pause for human approval (HITL)</li>
+     *   <li>REDACT: Mask sensitive content</li>
+     *   <li>WARN: Log warning, allow request</li>
+     *   <li>LOG: Audit only</li>
+     * </ul>
      */
     public enum OverrideAction {
         BLOCK("block"),
+        REQUIRE_APPROVAL("require_approval"),
+        REDACT("redact"),
         WARN("warn"),
-        LOG("log"),
-        REDACT("redact");
+        LOG("log");
 
         private final String value;
 
@@ -105,12 +113,21 @@ public final class PolicyTypes {
 
     /**
      * Action to take when a policy matches.
+     * <ul>
+     *   <li>BLOCK: Immediately block the request</li>
+     *   <li>REQUIRE_APPROVAL: Pause for human approval (HITL)</li>
+     *   <li>REDACT: Mask sensitive content</li>
+     *   <li>WARN: Log warning, allow request</li>
+     *   <li>LOG: Audit only</li>
+     *   <li>ALLOW: Explicitly allow (for overrides)</li>
+     * </ul>
      */
     public enum PolicyAction {
         BLOCK("block"),
+        REQUIRE_APPROVAL("require_approval"),
+        REDACT("redact"),
         WARN("warn"),
         LOG("log"),
-        REDACT("redact"),
         ALLOW("allow");
 
         private final String value;

--- a/src/test/java/com/getaxonflow/sdk/PolicyTest.java
+++ b/src/test/java/com/getaxonflow/sdk/PolicyTest.java
@@ -649,18 +649,20 @@ class PolicyTest {
         @DisplayName("OverrideAction enum values should serialize correctly")
         void overrideActionEnumValuesShouldSerializeCorrectly() {
             assertThat(OverrideAction.BLOCK.getValue()).isEqualTo("block");
+            assertThat(OverrideAction.REQUIRE_APPROVAL.getValue()).isEqualTo("require_approval");
+            assertThat(OverrideAction.REDACT.getValue()).isEqualTo("redact");
             assertThat(OverrideAction.WARN.getValue()).isEqualTo("warn");
             assertThat(OverrideAction.LOG.getValue()).isEqualTo("log");
-            assertThat(OverrideAction.REDACT.getValue()).isEqualTo("redact");
         }
 
         @Test
         @DisplayName("PolicyAction enum values should serialize correctly")
         void policyActionEnumValuesShouldSerializeCorrectly() {
             assertThat(PolicyAction.BLOCK.getValue()).isEqualTo("block");
+            assertThat(PolicyAction.REQUIRE_APPROVAL.getValue()).isEqualTo("require_approval");
+            assertThat(PolicyAction.REDACT.getValue()).isEqualTo("redact");
             assertThat(PolicyAction.WARN.getValue()).isEqualTo("warn");
             assertThat(PolicyAction.LOG.getValue()).isEqualTo("log");
-            assertThat(PolicyAction.REDACT.getValue()).isEqualTo("redact");
             assertThat(PolicyAction.ALLOW.getValue()).isEqualTo("allow");
         }
     }


### PR DESCRIPTION
## Summary
- Add `REQUIRE_APPROVAL` to PolicyAction and OverrideAction enums
- Enables Human-in-the-Loop (HITL) workflows for AI oversight

## Changes
- Updated `PolicyAction` enum to include `REQUIRE_APPROVAL`
- Updated `OverrideAction` enum to include `REQUIRE_APPROVAL`
- Added detailed Javadoc comments explaining each action
- Updated tests to verify new enum values

## Use Cases
- EU AI Act Article 14 compliance (human oversight for high-risk AI)
- SEBI AI/ML Circular (high-value transaction oversight)
- Admin access detection and sensitive data access control

## Behavior
| Edition | Behavior |
|---------|----------|
| Enterprise | Pauses execution, creates approval request in HITL queue |
| Community | Auto-approves immediately (upgrade path) |

## Testing
- All 359 tests pass
- BUILD SUCCESS