### PR TITLE
feat: add Code Governance Git Provider APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to the AxonFlow Java SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2025-12-29
+
+### Added
+
+- **Code Governance Git Provider APIs** (Enterprise): Create PRs from LLM-generated code
+  - `validateGitProvider()` - Validate credentials before saving
+  - `configureGitProvider()` - Configure GitHub, GitLab, or Bitbucket
+  - `listGitProviders()` - List configured providers
+  - `deleteGitProvider()` - Remove a provider
+  - `createPR()` - Create PR from generated code with audit trail
+  - `listPRs()` - List PRs with filtering
+  - `getPR()` - Get PR details
+  - `syncPRStatus()` - Sync status from Git provider
+
+- **New Types**: `GitProviderType`, `FileAction`, `CodeFile`, `CreatePRRequest`, `CreatePRResponse`, `PRRecord`, `ListPRsOptions`, `ListPRsResponse`
+
+- **Supported Git Providers**:
+  - GitHub (Cloud and Enterprise Server)
+  - GitLab (Cloud and Self-Managed)
+  - Bitbucket (Cloud and Server/Data Center)
+
+---
+
 ## [1.3.1] - 2025-12-29
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.getaxonflow</groupId>
     <artifactId>axonflow-sdk</artifactId>
-    <version>1.3.1</version>
+    <version>1.4.0</version>
     <packaging>jar</packaging>
 
     <name>AxonFlow Java SDK</name>

--- a/src/main/java/com/getaxonflow/sdk/AxonFlow.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlow.java
@@ -17,6 +17,7 @@ package com.getaxonflow.sdk;
 
 import com.getaxonflow.sdk.exceptions.*;
 import com.getaxonflow.sdk.types.*;
+import com.getaxonflow.sdk.types.codegovernance.*;
 import com.getaxonflow.sdk.types.policies.PolicyTypes.*;
 import com.getaxonflow.sdk.util.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -1341,6 +1342,216 @@ public final class AxonFlow implements Closeable {
         }
 
         return defaultMessage;
+    }
+
+    // ========================================================================
+    // Code Governance - Git Provider APIs (Enterprise)
+    // ========================================================================
+
+    /**
+     * Validates Git provider credentials without saving them.
+     *
+     * @param request the validation request with provider type and credentials
+     * @return validation result
+     * @throws IOException if the request fails
+     */
+    public ValidateGitProviderResponse validateGitProvider(ValidateGitProviderRequest request) throws IOException {
+        logger.debug("Validating Git provider: {}", request.getType());
+
+        String json = objectMapper.writeValueAsString(request);
+        RequestBody body = RequestBody.create(json, JSON);
+
+        Request.Builder builder = new Request.Builder()
+                .url(config.getAgentUrl() + "/api/v1/code-governance/git-providers/validate")
+                .post(body);
+
+        addAuthHeaders(builder);
+
+        try (Response response = httpClient.newCall(builder.build()).execute()) {
+            return parseResponse(response, ValidateGitProviderResponse.class);
+        }
+    }
+
+    /**
+     * Configures a Git provider for code governance.
+     *
+     * @param request the configuration request with provider type and credentials
+     * @return configuration result
+     * @throws IOException if the request fails
+     */
+    public ConfigureGitProviderResponse configureGitProvider(ConfigureGitProviderRequest request) throws IOException {
+        logger.debug("Configuring Git provider: {}", request.getType());
+
+        String json = objectMapper.writeValueAsString(request);
+        RequestBody body = RequestBody.create(json, JSON);
+
+        Request.Builder builder = new Request.Builder()
+                .url(config.getAgentUrl() + "/api/v1/code-governance/git-providers")
+                .post(body);
+
+        addAuthHeaders(builder);
+
+        try (Response response = httpClient.newCall(builder.build()).execute()) {
+            return parseResponse(response, ConfigureGitProviderResponse.class);
+        }
+    }
+
+    /**
+     * Lists configured Git providers.
+     *
+     * @return list of configured providers
+     * @throws IOException if the request fails
+     */
+    public ListGitProvidersResponse listGitProviders() throws IOException {
+        logger.debug("Listing Git providers");
+
+        Request.Builder builder = new Request.Builder()
+                .url(config.getAgentUrl() + "/api/v1/code-governance/git-providers")
+                .get();
+
+        addAuthHeaders(builder);
+
+        try (Response response = httpClient.newCall(builder.build()).execute()) {
+            return parseResponse(response, ListGitProvidersResponse.class);
+        }
+    }
+
+    /**
+     * Deletes a configured Git provider.
+     *
+     * @param providerType the provider type to delete
+     * @throws IOException if the request fails
+     */
+    public void deleteGitProvider(GitProviderType providerType) throws IOException {
+        logger.debug("Deleting Git provider: {}", providerType);
+
+        Request.Builder builder = new Request.Builder()
+                .url(config.getAgentUrl() + "/api/v1/code-governance/git-providers/" + providerType.getValue())
+                .delete();
+
+        addAuthHeaders(builder);
+
+        try (Response response = httpClient.newCall(builder.build()).execute()) {
+            handleErrorResponse(response);
+        }
+    }
+
+    /**
+     * Creates a Pull Request from LLM-generated code.
+     *
+     * @param request the PR creation request with repository info and files
+     * @return the created PR details
+     * @throws IOException if the request fails
+     */
+    public CreatePRResponse createPR(CreatePRRequest request) throws IOException {
+        logger.debug("Creating PR: {} in {}/{}", request.getTitle(), request.getOwner(), request.getRepo());
+
+        String json = objectMapper.writeValueAsString(request);
+        RequestBody body = RequestBody.create(json, JSON);
+
+        Request.Builder builder = new Request.Builder()
+                .url(config.getAgentUrl() + "/api/v1/code-governance/prs")
+                .post(body);
+
+        addAuthHeaders(builder);
+
+        try (Response response = httpClient.newCall(builder.build()).execute()) {
+            return parseResponse(response, CreatePRResponse.class);
+        }
+    }
+
+    /**
+     * Lists PRs with optional filtering.
+     *
+     * @param options filtering options (limit, offset, state)
+     * @return list of PRs
+     * @throws IOException if the request fails
+     */
+    public ListPRsResponse listPRs(ListPRsOptions options) throws IOException {
+        logger.debug("Listing PRs");
+
+        StringBuilder url = new StringBuilder(config.getAgentUrl() + "/api/v1/code-governance/prs");
+        StringBuilder query = new StringBuilder();
+
+        if (options != null) {
+            if (options.getLimit() != null) {
+                appendQueryParam(query, "limit", String.valueOf(options.getLimit()));
+            }
+            if (options.getOffset() != null) {
+                appendQueryParam(query, "offset", String.valueOf(options.getOffset()));
+            }
+            if (options.getState() != null) {
+                appendQueryParam(query, "state", options.getState());
+            }
+        }
+
+        if (query.length() > 0) {
+            url.append("?").append(query);
+        }
+
+        Request.Builder builder = new Request.Builder()
+                .url(url.toString())
+                .get();
+
+        addAuthHeaders(builder);
+
+        try (Response response = httpClient.newCall(builder.build()).execute()) {
+            return parseResponse(response, ListPRsResponse.class);
+        }
+    }
+
+    /**
+     * Lists PRs with default options.
+     *
+     * @return list of PRs
+     * @throws IOException if the request fails
+     */
+    public ListPRsResponse listPRs() throws IOException {
+        return listPRs(null);
+    }
+
+    /**
+     * Gets a specific PR by ID.
+     *
+     * @param prId the PR record ID
+     * @return the PR record
+     * @throws IOException if the request fails
+     */
+    public PRRecord getPR(String prId) throws IOException {
+        logger.debug("Getting PR: {}", prId);
+
+        Request.Builder builder = new Request.Builder()
+                .url(config.getAgentUrl() + "/api/v1/code-governance/prs/" + prId)
+                .get();
+
+        addAuthHeaders(builder);
+
+        try (Response response = httpClient.newCall(builder.build()).execute()) {
+            return parseResponse(response, PRRecord.class);
+        }
+    }
+
+    /**
+     * Syncs PR status from the Git provider.
+     *
+     * @param prId the PR record ID to sync
+     * @return the updated PR record
+     * @throws IOException if the request fails
+     */
+    public PRRecord syncPRStatus(String prId) throws IOException {
+        logger.debug("Syncing PR status: {}", prId);
+
+        RequestBody body = RequestBody.create("{}", JSON);
+
+        Request.Builder builder = new Request.Builder()
+                .url(config.getAgentUrl() + "/api/v1/code-governance/prs/" + prId + "/sync")
+                .post(body);
+
+        addAuthHeaders(builder);
+
+        try (Response response = httpClient.newCall(builder.build()).execute()) {
+            return parseResponse(response, PRRecord.class);
+        }
     }
 
     @Override

--- a/src/main/java/com/getaxonflow/sdk/types/codegovernance/CodeFile.java
+++ b/src/main/java/com/getaxonflow/sdk/types/codegovernance/CodeFile.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.sdk.types.codegovernance;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * A code file to include in a PR.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class CodeFile {
+
+    @JsonProperty("path")
+    private final String path;
+
+    @JsonProperty("content")
+    private final String content;
+
+    @JsonProperty("language")
+    private final String language;
+
+    @JsonProperty("action")
+    private final FileAction action;
+
+    public CodeFile(
+            @JsonProperty("path") String path,
+            @JsonProperty("content") String content,
+            @JsonProperty("language") String language,
+            @JsonProperty("action") FileAction action) {
+        this.path = Objects.requireNonNull(path, "path is required");
+        this.content = Objects.requireNonNull(content, "content is required");
+        this.language = language;
+        this.action = Objects.requireNonNull(action, "action is required");
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public FileAction getAction() {
+        return action;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String path;
+        private String content;
+        private String language;
+        private FileAction action;
+
+        public Builder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        public Builder content(String content) {
+            this.content = content;
+            return this;
+        }
+
+        public Builder language(String language) {
+            this.language = language;
+            return this;
+        }
+
+        public Builder action(FileAction action) {
+            this.action = action;
+            return this;
+        }
+
+        public CodeFile build() {
+            return new CodeFile(path, content, language, action);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CodeFile codeFile = (CodeFile) o;
+        return Objects.equals(path, codeFile.path) &&
+               Objects.equals(content, codeFile.content) &&
+               Objects.equals(language, codeFile.language) &&
+               action == codeFile.action;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path, content, language, action);
+    }
+
+    @Override
+    public String toString() {
+        return "CodeFile{" +
+               "path='" + path + '\'' +
+               ", language='" + language + '\'' +
+               ", action=" + action +
+               '}';
+    }
+}

--- a/src/main/java/com/getaxonflow/sdk/types/codegovernance/ConfigureGitProviderRequest.java
+++ b/src/main/java/com/getaxonflow/sdk/types/codegovernance/ConfigureGitProviderRequest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.sdk.types.codegovernance;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * Request to configure a Git provider.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class ConfigureGitProviderRequest {
+
+    @JsonProperty("type")
+    private final GitProviderType type;
+
+    @JsonProperty("token")
+    private final String token;
+
+    @JsonProperty("base_url")
+    private final String baseUrl;
+
+    @JsonProperty("app_id")
+    private final Integer appId;
+
+    @JsonProperty("installation_id")
+    private final Integer installationId;
+
+    @JsonProperty("private_key")
+    private final String privateKey;
+
+    public ConfigureGitProviderRequest(
+            @JsonProperty("type") GitProviderType type,
+            @JsonProperty("token") String token,
+            @JsonProperty("base_url") String baseUrl,
+            @JsonProperty("app_id") Integer appId,
+            @JsonProperty("installation_id") Integer installationId,
+            @JsonProperty("private_key") String privateKey) {
+        this.type = Objects.requireNonNull(type, "type is required");
+        this.token = token;
+        this.baseUrl = baseUrl;
+        this.appId = appId;
+        this.installationId = installationId;
+        this.privateKey = privateKey;
+    }
+
+    public GitProviderType getType() {
+        return type;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public Integer getAppId() {
+        return appId;
+    }
+
+    public Integer getInstallationId() {
+        return installationId;
+    }
+
+    public String getPrivateKey() {
+        return privateKey;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private GitProviderType type;
+        private String token;
+        private String baseUrl;
+        private Integer appId;
+        private Integer installationId;
+        private String privateKey;
+
+        public Builder type(GitProviderType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder token(String token) {
+            this.token = token;
+            return this;
+        }
+
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        public Builder appId(Integer appId) {
+            this.appId = appId;
+            return this;
+        }
+
+        public Builder installationId(Integer installationId) {
+            this.installationId = installationId;
+            return this;
+        }
+
+        public Builder privateKey(String privateKey) {
+            this.privateKey = privateKey;
+            return this;
+        }
+
+        public ConfigureGitProviderRequest build() {
+            return new ConfigureGitProviderRequest(type, token, baseUrl, appId, installationId, privateKey);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ConfigureGitProviderRequest that = (ConfigureGitProviderRequest) o;
+        return type == that.type &&
+               Objects.equals(token, that.token) &&
+               Objects.equals(baseUrl, that.baseUrl) &&
+               Objects.equals(appId, that.appId) &&
+               Objects.equals(installationId, that.installationId) &&
+               Objects.equals(privateKey, that.privateKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, token, baseUrl, appId, installationId, privateKey);
+    }
+
+    @Override
+    public String toString() {
+        return "ConfigureGitProviderRequest{" +
+               "type=" + type +
+               ", baseUrl='" + baseUrl + '\'' +
+               ", appId=" + appId +
+               ", installationId=" + installationId +
+               '}';
+    }
+}

--- a/src/main/java/com/getaxonflow/sdk/types/codegovernance/ConfigureGitProviderResponse.java
+++ b/src/main/java/com/getaxonflow/sdk/types/codegovernance/ConfigureGitProviderResponse.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.sdk.types.codegovernance;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * Response from Git provider configuration.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class ConfigureGitProviderResponse {
+
+    @JsonProperty("message")
+    private final String message;
+
+    @JsonProperty("type")
+    private final String type;
+
+    public ConfigureGitProviderResponse(
+            @JsonProperty("message") String message,
+            @JsonProperty("type") String type) {
+        this.message = message != null ? message : "";
+        this.type = type != null ? type : "";
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ConfigureGitProviderResponse that = (ConfigureGitProviderResponse) o;
+        return Objects.equals(message, that.message) && Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message, type);
+    }
+
+    @Override
+    public String toString() {
+        return "ConfigureGitProviderResponse{" +
+               "message='" + message + '\'' +
+               ", type='" + type + '\'' +
+               '}';
+    }
+}

--- a/src/main/java/com/getaxonflow/sdk/types/codegovernance/CreatePRRequest.java
+++ b/src/main/java/com/getaxonflow/sdk/types/codegovernance/CreatePRRequest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.sdk.types.codegovernance;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Request to create a PR from LLM-generated code.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class CreatePRRequest {
+
+    @JsonProperty("owner")
+    private final String owner;
+
+    @JsonProperty("repo")
+    private final String repo;
+
+    @JsonProperty("title")
+    private final String title;
+
+    @JsonProperty("description")
+    private final String description;
+
+    @JsonProperty("base_branch")
+    private final String baseBranch;
+
+    @JsonProperty("branch_name")
+    private final String branchName;
+
+    @JsonProperty("draft")
+    private final boolean draft;
+
+    @JsonProperty("files")
+    private final List<CodeFile> files;
+
+    @JsonProperty("agent_request_id")
+    private final String agentRequestId;
+
+    @JsonProperty("model")
+    private final String model;
+
+    @JsonProperty("policies_checked")
+    private final List<String> policiesChecked;
+
+    @JsonProperty("secrets_detected")
+    private final Integer secretsDetected;
+
+    @JsonProperty("unsafe_patterns")
+    private final Integer unsafePatterns;
+
+    public CreatePRRequest(
+            @JsonProperty("owner") String owner,
+            @JsonProperty("repo") String repo,
+            @JsonProperty("title") String title,
+            @JsonProperty("description") String description,
+            @JsonProperty("base_branch") String baseBranch,
+            @JsonProperty("branch_name") String branchName,
+            @JsonProperty("draft") boolean draft,
+            @JsonProperty("files") List<CodeFile> files,
+            @JsonProperty("agent_request_id") String agentRequestId,
+            @JsonProperty("model") String model,
+            @JsonProperty("policies_checked") List<String> policiesChecked,
+            @JsonProperty("secrets_detected") Integer secretsDetected,
+            @JsonProperty("unsafe_patterns") Integer unsafePatterns) {
+        this.owner = Objects.requireNonNull(owner, "owner is required");
+        this.repo = Objects.requireNonNull(repo, "repo is required");
+        this.title = Objects.requireNonNull(title, "title is required");
+        this.description = description;
+        this.baseBranch = baseBranch;
+        this.branchName = branchName;
+        this.draft = draft;
+        this.files = files != null ? Collections.unmodifiableList(files) : Collections.emptyList();
+        this.agentRequestId = agentRequestId;
+        this.model = model;
+        this.policiesChecked = policiesChecked != null ? Collections.unmodifiableList(policiesChecked) : null;
+        this.secretsDetected = secretsDetected;
+        this.unsafePatterns = unsafePatterns;
+    }
+
+    public String getOwner() { return owner; }
+    public String getRepo() { return repo; }
+    public String getTitle() { return title; }
+    public String getDescription() { return description; }
+    public String getBaseBranch() { return baseBranch; }
+    public String getBranchName() { return branchName; }
+    public boolean isDraft() { return draft; }
+    public List<CodeFile> getFiles() { return files; }
+    public String getAgentRequestId() { return agentRequestId; }
+    public String getModel() { return model; }
+    public List<String> getPoliciesChecked() { return policiesChecked; }
+    public Integer getSecretsDetected() { return secretsDetected; }
+    public Integer getUnsafePatterns() { return unsafePatterns; }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String owner;
+        private String repo;
+        private String title;
+        private String description;
+        private String baseBranch;
+        private String branchName;
+        private boolean draft;
+        private List<CodeFile> files;
+        private String agentRequestId;
+        private String model;
+        private List<String> policiesChecked;
+        private Integer secretsDetected;
+        private Integer unsafePatterns;
+
+        public Builder owner(String owner) { this.owner = owner; return this; }
+        public Builder repo(String repo) { this.repo = repo; return this; }
+        public Builder title(String title) { this.title = title; return this; }
+        public Builder description(String description) { this.description = description; return this; }
+        public Builder baseBranch(String baseBranch) { this.baseBranch = baseBranch; return this; }
+        public Builder branchName(String branchName) { this.branchName = branchName; return this; }
+        public Builder draft(boolean draft) { this.draft = draft; return this; }
+        public Builder files(List<CodeFile> files) { this.files = files; return this; }
+        public Builder agentRequestId(String agentRequestId) { this.agentRequestId = agentRequestId; return this; }
+        public Builder model(String model) { this.model = model; return this; }
+        public Builder policiesChecked(List<String> policiesChecked) { this.policiesChecked = policiesChecked; return this; }
+        public Builder secretsDetected(Integer secretsDetected) { this.secretsDetected = secretsDetected; return this; }
+        public Builder unsafePatterns(Integer unsafePatterns) { this.unsafePatterns = unsafePatterns; return this; }
+
+        public CreatePRRequest build() {
+            return new CreatePRRequest(owner, repo, title, description, baseBranch, branchName,
+                    draft, files, agentRequestId, model, policiesChecked, secretsDetected, unsafePatterns);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CreatePRRequest that = (CreatePRRequest) o;
+        return draft == that.draft &&
+               Objects.equals(owner, that.owner) &&
+               Objects.equals(repo, that.repo) &&
+               Objects.equals(title, that.title) &&
+               Objects.equals(files, that.files);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(owner, repo, title, draft, files);
+    }
+
+    @Override
+    public String toString() {
+        return "CreatePRRequest{" +
+               "owner='" + owner + '\'' +
+               ", repo='" + repo + '\'' +
+               ", title='" + title + '\'' +
+               ", draft=" + draft +
+               ", filesCount=" + (files != null ? files.size() : 0) +
+               '}';
+    }
+}

--- a/src/main/java/com/getaxonflow/sdk/types/codegovernance/CreatePRResponse.java
+++ b/src/main/java/com/getaxonflow/sdk/types/codegovernance/CreatePRResponse.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.sdk.types.codegovernance;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Response from PR creation.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class CreatePRResponse {
+
+    @JsonProperty("pr_id")
+    private final String prId;
+
+    @JsonProperty("pr_number")
+    private final int prNumber;
+
+    @JsonProperty("pr_url")
+    private final String prUrl;
+
+    @JsonProperty("state")
+    private final String state;
+
+    @JsonProperty("head_branch")
+    private final String headBranch;
+
+    @JsonProperty("created_at")
+    private final Instant createdAt;
+
+    public CreatePRResponse(
+            @JsonProperty("pr_id") String prId,
+            @JsonProperty("pr_number") int prNumber,
+            @JsonProperty("pr_url") String prUrl,
+            @JsonProperty("state") String state,
+            @JsonProperty("head_branch") String headBranch,
+            @JsonProperty("created_at") Instant createdAt) {
+        this.prId = prId;
+        this.prNumber = prNumber;
+        this.prUrl = prUrl;
+        this.state = state;
+        this.headBranch = headBranch;
+        this.createdAt = createdAt;
+    }
+
+    public String getPrId() { return prId; }
+    public int getPrNumber() { return prNumber; }
+    public String getPrUrl() { return prUrl; }
+    public String getState() { return state; }
+    public String getHeadBranch() { return headBranch; }
+    public Instant getCreatedAt() { return createdAt; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CreatePRResponse that = (CreatePRResponse) o;
+        return prNumber == that.prNumber &&
+               Objects.equals(prId, that.prId) &&
+               Objects.equals(prUrl, that.prUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(prId, prNumber, prUrl);
+    }
+
+    @Override
+    public String toString() {
+        return "CreatePRResponse{" +
+               "prId='" + prId + '\'' +
+               ", prNumber=" + prNumber +
+               ", prUrl='" + prUrl + '\'' +
+               ", state='" + state + '\'' +
+               '}';
+    }
+}

--- a/src/main/java/com/getaxonflow/sdk/types/codegovernance/FileAction.java
+++ b/src/main/java/com/getaxonflow/sdk/types/codegovernance/FileAction.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.sdk.types.codegovernance;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * File action for PR files.
+ */
+public enum FileAction {
+    CREATE("create"),
+    UPDATE("update"),
+    DELETE("delete");
+
+    private final String value;
+
+    FileAction(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    public static FileAction fromValue(String value) {
+        for (FileAction action : values()) {
+            if (action.value.equalsIgnoreCase(value)) {
+                return action;
+            }
+        }
+        throw new IllegalArgumentException("Unknown file action: " + value);
+    }
+}

--- a/src/main/java/com/getaxonflow/sdk/types/codegovernance/GitProviderInfo.java
+++ b/src/main/java/com/getaxonflow/sdk/types/codegovernance/GitProviderInfo.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.sdk.types.codegovernance;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * Basic info about a configured Git provider.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class GitProviderInfo {
+
+    @JsonProperty("type")
+    private final GitProviderType type;
+
+    public GitProviderInfo(@JsonProperty("type") GitProviderType type) {
+        this.type = type;
+    }
+
+    public GitProviderType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GitProviderInfo that = (GitProviderInfo) o;
+        return type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type);
+    }
+
+    @Override
+    public String toString() {
+        return "GitProviderInfo{type=" + type + '}';
+    }
+}

--- a/src/main/java/com/getaxonflow/sdk/types/codegovernance/GitProviderType.java
+++ b/src/main/java/com/getaxonflow/sdk/types/codegovernance/GitProviderType.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.sdk.types.codegovernance;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Supported Git providers for code governance.
+ */
+public enum GitProviderType {
+    GITHUB("github"),
+    GITLAB("gitlab"),
+    BITBUCKET("bitbucket");
+
+    private final String value;
+
+    GitProviderType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    public static GitProviderType fromValue(String value) {
+        for (GitProviderType type : values()) {
+            if (type.value.equalsIgnoreCase(value)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown Git provider type: " + value);
+    }
+}

--- a/src/main/java/com/getaxonflow/sdk/types/codegovernance/ListGitProvidersResponse.java
+++ b/src/main/java/com/getaxonflow/sdk/types/codegovernance/ListGitProvidersResponse.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.sdk.types.codegovernance;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Response listing configured Git providers.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class ListGitProvidersResponse {
+
+    @JsonProperty("providers")
+    private final List<GitProviderInfo> providers;
+
+    @JsonProperty("count")
+    private final int count;
+
+    public ListGitProvidersResponse(
+            @JsonProperty("providers") List<GitProviderInfo> providers,
+            @JsonProperty("count") int count) {
+        this.providers = providers != null ? Collections.unmodifiableList(providers) : Collections.emptyList();
+        this.count = count;
+    }
+
+    public List<GitProviderInfo> getProviders() {
+        return providers;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ListGitProvidersResponse that = (ListGitProvidersResponse) o;
+        return count == that.count && Objects.equals(providers, that.providers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(providers, count);
+    }
+
+    @Override
+    public String toString() {
+        return "ListGitProvidersResponse{" +
+               "providers=" + providers +
+               ", count=" + count +
+               '}';
+    }
+}

--- a/src/main/java/com/getaxonflow/sdk/types/codegovernance/ListPRsOptions.java
+++ b/src/main/java/com/getaxonflow/sdk/types/codegovernance/ListPRsOptions.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.sdk.types.codegovernance;
+
+import java.util.Objects;
+
+/**
+ * Options for listing PRs.
+ */
+public final class ListPRsOptions {
+
+    private final Integer limit;
+    private final Integer offset;
+    private final String state;
+
+    private ListPRsOptions(Integer limit, Integer offset, String state) {
+        this.limit = limit;
+        this.offset = offset;
+        this.state = state;
+    }
+
+    public Integer getLimit() { return limit; }
+    public Integer getOffset() { return offset; }
+    public String getState() { return state; }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Integer limit;
+        private Integer offset;
+        private String state;
+
+        public Builder limit(Integer limit) { this.limit = limit; return this; }
+        public Builder offset(Integer offset) { this.offset = offset; return this; }
+        public Builder state(String state) { this.state = state; return this; }
+
+        public ListPRsOptions build() {
+            return new ListPRsOptions(limit, offset, state);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ListPRsOptions that = (ListPRsOptions) o;
+        return Objects.equals(limit, that.limit) &&
+               Objects.equals(offset, that.offset) &&
+               Objects.equals(state, that.state);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(limit, offset, state);
+    }
+
+    @Override
+    public String toString() {
+        return "ListPRsOptions{" +
+               "limit=" + limit +
+               ", offset=" + offset +
+               ", state='" + state + '\'' +
+               '}';
+    }
+}

--- a/src/main/java/com/getaxonflow/sdk/types/codegovernance/ListPRsResponse.java
+++ b/src/main/java/com/getaxonflow/sdk/types/codegovernance/ListPRsResponse.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.sdk.types.codegovernance;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Response listing PRs.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class ListPRsResponse {
+
+    @JsonProperty("prs")
+    private final List<PRRecord> prs;
+
+    @JsonProperty("count")
+    private final int count;
+
+    public ListPRsResponse(
+            @JsonProperty("prs") List<PRRecord> prs,
+            @JsonProperty("count") int count) {
+        this.prs = prs != null ? Collections.unmodifiableList(prs) : Collections.emptyList();
+        this.count = count;
+    }
+
+    public List<PRRecord> getPrs() {
+        return prs;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ListPRsResponse that = (ListPRsResponse) o;
+        return count == that.count && Objects.equals(prs, that.prs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(prs, count);
+    }
+
+    @Override
+    public String toString() {
+        return "ListPRsResponse{" +
+               "prs=" + prs +
+               ", count=" + count +
+               '}';
+    }
+}

--- a/src/main/java/com/getaxonflow/sdk/types/codegovernance/PRRecord.java
+++ b/src/main/java/com/getaxonflow/sdk/types/codegovernance/PRRecord.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.sdk.types.codegovernance;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A PR record in the system.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class PRRecord {
+
+    @JsonProperty("id")
+    private final String id;
+
+    @JsonProperty("pr_number")
+    private final int prNumber;
+
+    @JsonProperty("pr_url")
+    private final String prUrl;
+
+    @JsonProperty("title")
+    private final String title;
+
+    @JsonProperty("state")
+    private final String state;
+
+    @JsonProperty("owner")
+    private final String owner;
+
+    @JsonProperty("repo")
+    private final String repo;
+
+    @JsonProperty("head_branch")
+    private final String headBranch;
+
+    @JsonProperty("base_branch")
+    private final String baseBranch;
+
+    @JsonProperty("files_count")
+    private final int filesCount;
+
+    @JsonProperty("secrets_detected")
+    private final int secretsDetected;
+
+    @JsonProperty("unsafe_patterns")
+    private final int unsafePatterns;
+
+    @JsonProperty("created_at")
+    private final Instant createdAt;
+
+    @JsonProperty("created_by")
+    private final String createdBy;
+
+    @JsonProperty("provider_type")
+    private final String providerType;
+
+    public PRRecord(
+            @JsonProperty("id") String id,
+            @JsonProperty("pr_number") int prNumber,
+            @JsonProperty("pr_url") String prUrl,
+            @JsonProperty("title") String title,
+            @JsonProperty("state") String state,
+            @JsonProperty("owner") String owner,
+            @JsonProperty("repo") String repo,
+            @JsonProperty("head_branch") String headBranch,
+            @JsonProperty("base_branch") String baseBranch,
+            @JsonProperty("files_count") int filesCount,
+            @JsonProperty("secrets_detected") int secretsDetected,
+            @JsonProperty("unsafe_patterns") int unsafePatterns,
+            @JsonProperty("created_at") Instant createdAt,
+            @JsonProperty("created_by") String createdBy,
+            @JsonProperty("provider_type") String providerType) {
+        this.id = id;
+        this.prNumber = prNumber;
+        this.prUrl = prUrl;
+        this.title = title;
+        this.state = state;
+        this.owner = owner;
+        this.repo = repo;
+        this.headBranch = headBranch;
+        this.baseBranch = baseBranch;
+        this.filesCount = filesCount;
+        this.secretsDetected = secretsDetected;
+        this.unsafePatterns = unsafePatterns;
+        this.createdAt = createdAt;
+        this.createdBy = createdBy;
+        this.providerType = providerType;
+    }
+
+    public String getId() { return id; }
+    public int getPrNumber() { return prNumber; }
+    public String getPrUrl() { return prUrl; }
+    public String getTitle() { return title; }
+    public String getState() { return state; }
+    public String getOwner() { return owner; }
+    public String getRepo() { return repo; }
+    public String getHeadBranch() { return headBranch; }
+    public String getBaseBranch() { return baseBranch; }
+    public int getFilesCount() { return filesCount; }
+    public int getSecretsDetected() { return secretsDetected; }
+    public int getUnsafePatterns() { return unsafePatterns; }
+    public Instant getCreatedAt() { return createdAt; }
+    public String getCreatedBy() { return createdBy; }
+    public String getProviderType() { return providerType; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PRRecord prRecord = (PRRecord) o;
+        return prNumber == prRecord.prNumber &&
+               Objects.equals(id, prRecord.id) &&
+               Objects.equals(owner, prRecord.owner) &&
+               Objects.equals(repo, prRecord.repo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, prNumber, owner, repo);
+    }
+
+    @Override
+    public String toString() {
+        return "PRRecord{" +
+               "id='" + id + '\'' +
+               ", prNumber=" + prNumber +
+               ", title='" + title + '\'' +
+               ", state='" + state + '\'' +
+               ", owner='" + owner + '\'' +
+               ", repo='" + repo + '\'' +
+               '}';
+    }
+}

--- a/src/main/java/com/getaxonflow/sdk/types/codegovernance/ValidateGitProviderRequest.java
+++ b/src/main/java/com/getaxonflow/sdk/types/codegovernance/ValidateGitProviderRequest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.sdk.types.codegovernance;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * Request to validate Git provider credentials.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class ValidateGitProviderRequest {
+
+    @JsonProperty("type")
+    private final GitProviderType type;
+
+    @JsonProperty("token")
+    private final String token;
+
+    @JsonProperty("base_url")
+    private final String baseUrl;
+
+    @JsonProperty("app_id")
+    private final Integer appId;
+
+    @JsonProperty("installation_id")
+    private final Integer installationId;
+
+    @JsonProperty("private_key")
+    private final String privateKey;
+
+    public ValidateGitProviderRequest(
+            @JsonProperty("type") GitProviderType type,
+            @JsonProperty("token") String token,
+            @JsonProperty("base_url") String baseUrl,
+            @JsonProperty("app_id") Integer appId,
+            @JsonProperty("installation_id") Integer installationId,
+            @JsonProperty("private_key") String privateKey) {
+        this.type = Objects.requireNonNull(type, "type is required");
+        this.token = token;
+        this.baseUrl = baseUrl;
+        this.appId = appId;
+        this.installationId = installationId;
+        this.privateKey = privateKey;
+    }
+
+    public GitProviderType getType() {
+        return type;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public Integer getAppId() {
+        return appId;
+    }
+
+    public Integer getInstallationId() {
+        return installationId;
+    }
+
+    public String getPrivateKey() {
+        return privateKey;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private GitProviderType type;
+        private String token;
+        private String baseUrl;
+        private Integer appId;
+        private Integer installationId;
+        private String privateKey;
+
+        public Builder type(GitProviderType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder token(String token) {
+            this.token = token;
+            return this;
+        }
+
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        public Builder appId(Integer appId) {
+            this.appId = appId;
+            return this;
+        }
+
+        public Builder installationId(Integer installationId) {
+            this.installationId = installationId;
+            return this;
+        }
+
+        public Builder privateKey(String privateKey) {
+            this.privateKey = privateKey;
+            return this;
+        }
+
+        public ValidateGitProviderRequest build() {
+            return new ValidateGitProviderRequest(type, token, baseUrl, appId, installationId, privateKey);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ValidateGitProviderRequest that = (ValidateGitProviderRequest) o;
+        return type == that.type &&
+               Objects.equals(token, that.token) &&
+               Objects.equals(baseUrl, that.baseUrl) &&
+               Objects.equals(appId, that.appId) &&
+               Objects.equals(installationId, that.installationId) &&
+               Objects.equals(privateKey, that.privateKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, token, baseUrl, appId, installationId, privateKey);
+    }
+
+    @Override
+    public String toString() {
+        return "ValidateGitProviderRequest{" +
+               "type=" + type +
+               ", baseUrl='" + baseUrl + '\'' +
+               '}';
+    }
+}

--- a/src/main/java/com/getaxonflow/sdk/types/codegovernance/ValidateGitProviderResponse.java
+++ b/src/main/java/com/getaxonflow/sdk/types/codegovernance/ValidateGitProviderResponse.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.sdk.types.codegovernance;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * Response from Git provider validation.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class ValidateGitProviderResponse {
+
+    @JsonProperty("valid")
+    private final boolean valid;
+
+    @JsonProperty("message")
+    private final String message;
+
+    public ValidateGitProviderResponse(
+            @JsonProperty("valid") boolean valid,
+            @JsonProperty("message") String message) {
+        this.valid = valid;
+        this.message = message != null ? message : "";
+    }
+
+    public boolean isValid() {
+        return valid;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ValidateGitProviderResponse that = (ValidateGitProviderResponse) o;
+        return valid == that.valid && Objects.equals(message, that.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(valid, message);
+    }
+
+    @Override
+    public String toString() {
+        return "ValidateGitProviderResponse{" +
+               "valid=" + valid +
+               ", message='" + message + '\'' +
+               '}';
+    }
+}

--- a/src/main/java/com/getaxonflow/sdk/types/codegovernance/package-info.java
+++ b/src/main/java/com/getaxonflow/sdk/types/codegovernance/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Code Governance types for enterprise Git provider integration.
+ *
+ * <p>This package provides types for:
+ * <ul>
+ *   <li>Git provider configuration (GitHub, GitLab, Bitbucket)</li>
+ *   <li>Pull request creation from LLM-generated code</li>
+ *   <li>PR tracking and status synchronization</li>
+ * </ul>
+ *
+ * @see com.getaxonflow.sdk.AxonFlow#validateGitProvider
+ * @see com.getaxonflow.sdk.AxonFlow#configureGitProvider
+ * @see com.getaxonflow.sdk.AxonFlow#createPR
+ */
+package com.getaxonflow.sdk.types.codegovernance;


### PR DESCRIPTION
## Summary

Add Code Governance Git Provider APIs for enterprise users to create PRs from LLM-generated code.

## New Methods

- `validateGitProvider()` - Validate credentials before saving
- `configureGitProvider()` - Configure GitHub, GitLab, or Bitbucket
- `listGitProviders()` - List configured providers
- `deleteGitProvider()` - Remove a provider
- `createPR()` - Create PR from generated code with audit trail
- `listPRs()` - List PRs with filtering
- `getPR()` - Get PR details
- `syncPRStatus()` - Sync status from Git provider

## New Types

- `GitProviderType`, `FileAction`, `CodeFile`
- `ConfigureGitProviderRequest`, `ConfigureGitProviderResponse`
- `ValidateGitProviderRequest`, `ValidateGitProviderResponse`
- `GitProviderInfo`, `ListGitProvidersResponse`
- `CreatePRRequest`, `CreatePRResponse`
- `PRRecord`, `ListPRsOptions`, `ListPRsResponse`

## Supported Git Providers

- GitHub (Cloud and Enterprise Server)
- GitLab (Cloud and Self-Managed)
- Bitbucket (Cloud and Server/Data Center)

## Test Plan

- [x] All existing tests pass
- [x] Code compiles successfully
- [x] Version bumped to 1.4.0
- [x] CHANGELOG updated