### PR TITLE
feat(policies): add enterprise policy features and convenience methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the AxonFlow Java SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2025-12-29
+
+### Added
+
+- **Enterprise Policy Features**:
+  - `organizationId()` builder method in `CreateStaticPolicyRequest` for organization-tier policies
+  - `organizationId()` builder method in `ListStaticPoliciesOptions` for filtering by organization
+  - `listPolicyOverrides()` method to list all active policy overrides
+
+- **Convenience Methods**:
+  - `listStaticPolicies(PolicyTier tier, String organizationId)` - filter by tier and organization
+  - `listStaticPolicies(PolicyTier tier, PolicyCategory category)` - filter by tier and category
+  - `listStaticPolicies(PolicyCategory category)` - filter by category
+  - `getEffectiveStaticPolicies(PolicyCategory category)` - filter effective policies by category
+
+---
+
 ## [1.5.0] - 2025-12-29
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.getaxonflow</groupId>
     <artifactId>axonflow-sdk</artifactId>
-    <version>1.5.0</version>
+    <version>1.6.0</version>
     <packaging>jar</packaging>
 
     <name>AxonFlow Java SDK</name>

--- a/src/main/java/com/getaxonflow/sdk/AxonFlow.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlow.java
@@ -633,7 +633,7 @@ public final class AxonFlow implements Closeable {
      * @return list of static policies
      */
     public List<StaticPolicy> listStaticPolicies() {
-        return listStaticPolicies(null);
+        return listStaticPolicies((ListStaticPoliciesOptions) null);
     }
 
     /**
@@ -651,6 +651,46 @@ public final class AxonFlow implements Closeable {
                 return wrapper.getPolicies() != null ? wrapper.getPolicies() : java.util.Collections.emptyList();
             }
         }, "listStaticPolicies");
+    }
+
+    /**
+     * Lists static policies filtered by tier and organization ID (Enterprise).
+     *
+     * @param tier           the policy tier
+     * @param organizationId the organization ID
+     * @return list of static policies
+     */
+    public List<StaticPolicy> listStaticPolicies(PolicyTier tier, String organizationId) {
+        return listStaticPolicies(ListStaticPoliciesOptions.builder()
+                .tier(tier)
+                .organizationId(organizationId)
+                .build());
+    }
+
+    /**
+     * Lists static policies filtered by tier and category.
+     *
+     * @param tier     the policy tier
+     * @param category the policy category
+     * @return list of static policies
+     */
+    public List<StaticPolicy> listStaticPolicies(PolicyTier tier, PolicyCategory category) {
+        return listStaticPolicies(ListStaticPoliciesOptions.builder()
+                .tier(tier)
+                .category(category)
+                .build());
+    }
+
+    /**
+     * Lists static policies filtered by category.
+     *
+     * @param category the policy category
+     * @return list of static policies
+     */
+    public List<StaticPolicy> listStaticPolicies(PolicyCategory category) {
+        return listStaticPolicies(ListStaticPoliciesOptions.builder()
+                .category(category)
+                .build());
     }
 
     /**
@@ -750,7 +790,19 @@ public final class AxonFlow implements Closeable {
      * @return list of effective policies
      */
     public List<StaticPolicy> getEffectiveStaticPolicies() {
-        return getEffectiveStaticPolicies(null);
+        return getEffectiveStaticPolicies((EffectivePoliciesOptions) null);
+    }
+
+    /**
+     * Gets effective static policies filtered by category.
+     *
+     * @param category the policy category
+     * @return list of effective policies
+     */
+    public List<StaticPolicy> getEffectiveStaticPolicies(PolicyCategory category) {
+        return getEffectiveStaticPolicies(EffectivePoliciesOptions.builder()
+                .category(category)
+                .build());
     }
 
     /**
@@ -856,6 +908,21 @@ public final class AxonFlow implements Closeable {
                 return null;
             }
         }, "deletePolicyOverride");
+    }
+
+    /**
+     * Lists all active policy overrides (Enterprise).
+     *
+     * @return list of policy overrides
+     */
+    public List<PolicyOverride> listPolicyOverrides() {
+        return retryExecutor.execute(() -> {
+            Request httpRequest = buildRequest("GET", "/api/v1/policies/overrides", null);
+            try (Response response = httpClient.newCall(httpRequest).execute()) {
+                PolicyOverride[] overrides = parseResponse(response, PolicyOverride[].class);
+                return overrides != null ? java.util.Arrays.asList(overrides) : java.util.Collections.emptyList();
+            }
+        }, "listPolicyOverrides");
     }
 
     // ========================================================================
@@ -1141,6 +1208,9 @@ public final class AxonFlow implements Closeable {
         }
         if (options.getTier() != null) {
             appendQueryParam(query, "tier", options.getTier().getValue());
+        }
+        if (options.getOrganizationId() != null) {
+            appendQueryParam(query, "organization_id", options.getOrganizationId());
         }
         if (options.getEnabled() != null) {
             appendQueryParam(query, "enabled", options.getEnabled().toString());

--- a/src/main/java/com/getaxonflow/sdk/types/policies/PolicyTypes.java
+++ b/src/main/java/com/getaxonflow/sdk/types/policies/PolicyTypes.java
@@ -267,6 +267,7 @@ public final class PolicyTypes {
     public static class ListStaticPoliciesOptions {
         private PolicyCategory category;
         private PolicyTier tier;
+        private String organizationId;
         private Boolean enabled;
         private Integer limit;
         private Integer offset;
@@ -280,6 +281,7 @@ public final class PolicyTypes {
 
         public PolicyCategory getCategory() { return category; }
         public PolicyTier getTier() { return tier; }
+        public String getOrganizationId() { return organizationId; }
         public Boolean getEnabled() { return enabled; }
         public Integer getLimit() { return limit; }
         public Integer getOffset() { return offset; }
@@ -297,6 +299,17 @@ public final class PolicyTypes {
 
             public Builder tier(PolicyTier tier) {
                 options.tier = tier;
+                return this;
+            }
+
+            /**
+             * Filters policies by organization ID (Enterprise).
+             *
+             * @param organizationId the organization ID
+             * @return this builder
+             */
+            public Builder organizationId(String organizationId) {
+                options.organizationId = organizationId;
                 return this;
             }
 
@@ -344,6 +357,8 @@ public final class PolicyTypes {
         private String description;
         private PolicyCategory category;
         private PolicyTier tier = PolicyTier.TENANT;
+        @JsonProperty("organization_id")
+        private String organizationId;
         private String pattern;
         private PolicySeverity severity = PolicySeverity.MEDIUM;
         private boolean enabled = true;
@@ -357,6 +372,7 @@ public final class PolicyTypes {
         public String getDescription() { return description; }
         public PolicyCategory getCategory() { return category; }
         public PolicyTier getTier() { return tier; }
+        public String getOrganizationId() { return organizationId; }
         public String getPattern() { return pattern; }
         public PolicySeverity getSeverity() { return severity; }
         public boolean isEnabled() { return enabled; }
@@ -382,6 +398,17 @@ public final class PolicyTypes {
 
             public Builder tier(PolicyTier tier) {
                 request.tier = tier;
+                return this;
+            }
+
+            /**
+             * Sets the organization ID for organization-tier policies (Enterprise).
+             *
+             * @param organizationId the organization ID
+             * @return this builder
+             */
+            public Builder organizationId(String organizationId) {
+                request.organizationId = organizationId;
                 return this;
             }
 


### PR DESCRIPTION
## Summary

- Added `organizationId()` builder method to `CreateStaticPolicyRequest` for organization-tier policies
- Added `organizationId()` builder method to `ListStaticPoliciesOptions` for filtering by organization  
- Added `listPolicyOverrides()` method to list all active policy overrides
- Added convenience overloads for `listStaticPolicies()`
- Added convenience overload for `getEffectiveStaticPolicies()`

## Test plan

- [x] All existing tests pass
- [x] Enterprise examples build successfully with local SDK