### PR TITLE
chore: add v1.7.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the AxonFlow Java SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2025-12-30
+
+### Fixed
+
+- Fixed `PolicyOverride` JSON field mappings (`action_override`, `override_reason`)
+- Fixed `listPolicyOverrides()` endpoint path and response parsing
+- Fixed `getStaticPolicyVersions()` response parsing
+
+### Changed
+
+- `CreatePolicyOverrideRequest.Builder`: `action()` → `actionOverride()`, `reason()` → `overrideReason()`
+
+> **Note:** These changes affect Enterprise users only. Community users can skip this release.
+
+---
+
 ## [1.6.0] - 2025-12-29
 
 ### Added


### PR DESCRIPTION
Add changelog entry for v1.7.0 release (PolicyOverride fixes - Enterprise only).