### PR TITLE
feat(wcp): execution boundary semantics + checkpoint types for v7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the AxonFlow Java SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.4.0] - 2026-04-18
+
+### Added
+
+- **Execution boundary semantics** — `retryPolicy` field on `StepGateRequest`
+  (via builder: `.retryPolicy("reevaluate")`). Controls cached vs fresh
+  evaluation for the same step boundary.
+- **Step gate response metadata** — `cached` (boolean) and `decisionSource`
+  (String) fields on `StepGateResponse` via `isCached()` and
+  `getDecisionSource()`.
+- **Workflow checkpoints** — `getCheckpoints(workflowId)` lists step-gate
+  checkpoints. `resumeFromLastCheckpoint(workflowId)` resumes from last
+  checkpoint (Evaluation+). `resumeFromCheckpoint(workflowId, checkpointId)`
+  resumes from a specific checkpoint (Enterprise).
+- **Checkpoint types** — `Checkpoint`, `CheckpointListResponse`, and
+  `ResumeFromCheckpointResponse` with Jackson deserialization.
+
 ## [5.3.0] - 2026-04-09
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.getaxonflow</groupId>
     <artifactId>axonflow-sdk</artifactId>
-    <version>5.3.0</version>
+    <version>5.4.0</version>
     <packaging>jar</packaging>
 
     <name>AxonFlow Java SDK</name>

--- a/src/main/java/com/getaxonflow/sdk/AxonFlow.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlow.java
@@ -5136,6 +5136,79 @@ public final class AxonFlow implements Closeable {
   }
 
   /**
+   * Lists step-gate checkpoints for a workflow. Available in all tiers.
+   *
+   * @param workflowId workflow ID
+   * @return checkpoint list
+   */
+  public com.getaxonflow.sdk.types.workflow.WorkflowTypes.CheckpointListResponse getCheckpoints(
+      String workflowId) {
+    Objects.requireNonNull(workflowId, "workflowId cannot be null");
+    return retryExecutor.execute(
+        () -> {
+          Request httpRequest =
+              buildOrchestratorRequest("GET", "/api/v1/workflows/" + workflowId + "/checkpoints", null);
+          try (Response response = httpClient.newCall(httpRequest).execute()) {
+            return parseResponse(
+                response,
+                new TypeReference<
+                    com.getaxonflow.sdk.types.workflow.WorkflowTypes.CheckpointListResponse>() {});
+          }
+        },
+        "getCheckpoints");
+  }
+
+  /**
+   * Resumes a workflow from its last resumable checkpoint. Evaluation+ tier.
+   *
+   * @param workflowId workflow ID
+   * @return resume result with fresh decision
+   */
+  public com.getaxonflow.sdk.types.workflow.WorkflowTypes.ResumeFromCheckpointResponse resumeFromLastCheckpoint(
+      String workflowId) {
+    Objects.requireNonNull(workflowId, "workflowId cannot be null");
+    return retryExecutor.execute(
+        () -> {
+          Request httpRequest =
+              buildOrchestratorRequest("POST", "/api/v1/workflows/" + workflowId + "/checkpoints/resume", "{}");
+          try (Response response = httpClient.newCall(httpRequest).execute()) {
+            return parseResponse(
+                response,
+                new TypeReference<
+                    com.getaxonflow.sdk.types.workflow.WorkflowTypes.ResumeFromCheckpointResponse>() {});
+          }
+        },
+        "resumeFromLastCheckpoint");
+  }
+
+  /**
+   * Resumes a workflow from a specific checkpoint. Enterprise only.
+   *
+   * @param workflowId workflow ID
+   * @param checkpointId checkpoint database ID
+   * @return resume result with fresh decision
+   */
+  public com.getaxonflow.sdk.types.workflow.WorkflowTypes.ResumeFromCheckpointResponse resumeFromCheckpoint(
+      String workflowId, long checkpointId) {
+    Objects.requireNonNull(workflowId, "workflowId cannot be null");
+    return retryExecutor.execute(
+        () -> {
+          Request httpRequest =
+              buildOrchestratorRequest(
+                  "POST",
+                  "/api/v1/workflows/" + workflowId + "/checkpoints/" + checkpointId + "/resume",
+                  "{}");
+          try (Response response = httpClient.newCall(httpRequest).execute()) {
+            return parseResponse(
+                response,
+                new TypeReference<
+                    com.getaxonflow.sdk.types.workflow.WorkflowTypes.ResumeFromCheckpointResponse>() {});
+          }
+        },
+        "resumeFromCheckpoint");
+  }
+
+  /**
    * Lists workflows with optional filters.
    *
    * @param options filter and pagination options

--- a/src/main/java/com/getaxonflow/sdk/types/workflow/WorkflowTypes.java
+++ b/src/main/java/com/getaxonflow/sdk/types/workflow/WorkflowTypes.java
@@ -458,14 +458,28 @@ public final class WorkflowTypes {
     @JsonProperty("tool_context")
     private final ToolContext toolContext;
 
-    /** Backward-compatible constructor without toolContext. */
+    @JsonProperty("retry_policy")
+    private final String retryPolicy;
+
+    /** Backward-compatible constructor without toolContext or retryPolicy. */
     public StepGateRequest(
         String stepName,
         StepType stepType,
         Map<String, Object> stepInput,
         String model,
         String provider) {
-      this(stepName, stepType, stepInput, model, provider, null);
+      this(stepName, stepType, stepInput, model, provider, null, null);
+    }
+
+    /** Backward-compatible constructor without retryPolicy. */
+    public StepGateRequest(
+        String stepName,
+        StepType stepType,
+        Map<String, Object> stepInput,
+        String model,
+        String provider,
+        ToolContext toolContext) {
+      this(stepName, stepType, stepInput, model, provider, toolContext, null);
     }
 
     @JsonCreator
@@ -475,7 +489,8 @@ public final class WorkflowTypes {
         @JsonProperty("step_input") Map<String, Object> stepInput,
         @JsonProperty("model") String model,
         @JsonProperty("provider") String provider,
-        @JsonProperty("tool_context") ToolContext toolContext) {
+        @JsonProperty("tool_context") ToolContext toolContext,
+        @JsonProperty("retry_policy") String retryPolicy) {
       this.stepName = stepName;
       this.stepType = Objects.requireNonNull(stepType, "stepType is required");
       this.stepInput =
@@ -483,6 +498,7 @@ public final class WorkflowTypes {
       this.model = model;
       this.provider = provider;
       this.toolContext = toolContext;
+      this.retryPolicy = retryPolicy;
     }
 
     public String getStepName() {
@@ -509,6 +525,14 @@ public final class WorkflowTypes {
       return toolContext;
     }
 
+    /**
+     * Returns the retry policy for this step gate request.
+     * "idempotent" (default): return cached decision. "reevaluate": force fresh evaluation.
+     */
+    public String getRetryPolicy() {
+      return retryPolicy;
+    }
+
     public static Builder builder() {
       return new Builder();
     }
@@ -520,6 +544,7 @@ public final class WorkflowTypes {
       private String model;
       private String provider;
       private ToolContext toolContext;
+      private String retryPolicy;
 
       public Builder stepName(String stepName) {
         this.stepName = stepName;
@@ -551,8 +576,15 @@ public final class WorkflowTypes {
         return this;
       }
 
+      /** Set the retry policy: "idempotent" (default) or "reevaluate". */
+      public Builder retryPolicy(String retryPolicy) {
+        this.retryPolicy = retryPolicy;
+        return this;
+      }
+
       public StepGateRequest build() {
-        return new StepGateRequest(stepName, stepType, stepInput, model, provider, toolContext);
+        return new StepGateRequest(
+            stepName, stepType, stepInput, model, provider, toolContext, retryPolicy);
       }
     }
   }
@@ -582,6 +614,12 @@ public final class WorkflowTypes {
     @JsonProperty("policies_matched")
     private final List<PolicyMatch> policiesMatched;
 
+    @JsonProperty("cached")
+    private final boolean cached;
+
+    @JsonProperty("decision_source")
+    private final String decisionSource;
+
     @JsonCreator
     public StepGateResponse(
         @JsonProperty("decision") GateDecision decision,
@@ -590,7 +628,9 @@ public final class WorkflowTypes {
         @JsonProperty("policy_ids") List<String> policyIds,
         @JsonProperty("approval_url") String approvalUrl,
         @JsonProperty("policies_evaluated") List<PolicyMatch> policiesEvaluated,
-        @JsonProperty("policies_matched") List<PolicyMatch> policiesMatched) {
+        @JsonProperty("policies_matched") List<PolicyMatch> policiesMatched,
+        @JsonProperty("cached") boolean cached,
+        @JsonProperty("decision_source") String decisionSource) {
       this.decision = decision;
       this.stepId = stepId;
       this.reason = reason;
@@ -605,6 +645,8 @@ public final class WorkflowTypes {
           policiesMatched != null
               ? Collections.unmodifiableList(policiesMatched)
               : Collections.emptyList();
+      this.cached = cached;
+      this.decisionSource = decisionSource;
     }
 
     public GateDecision getDecision() {
@@ -645,6 +687,20 @@ public final class WorkflowTypes {
      */
     public List<PolicyMatch> getPoliciesMatched() {
       return policiesMatched;
+    }
+
+    /**
+     * Returns whether this response was served from a prior decision rather than a fresh evaluation.
+     */
+    public boolean isCached() {
+      return cached;
+    }
+
+    /**
+     * Returns how the decision was produced: "fresh" or "cached".
+     */
+    public String getDecisionSource() {
+      return decisionSource;
     }
 
     public boolean isAllowed() {

--- a/src/main/java/com/getaxonflow/sdk/types/workflow/WorkflowTypes.java
+++ b/src/main/java/com/getaxonflow/sdk/types/workflow/WorkflowTypes.java
@@ -716,6 +716,158 @@ public final class WorkflowTypes {
     }
   }
 
+  /** A governance-aware resume boundary at a step-gate evaluation. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static final class Checkpoint {
+
+    @JsonProperty("id")
+    private final long id;
+
+    @JsonProperty("workflow_id")
+    private final String workflowId;
+
+    @JsonProperty("step_id")
+    private final String stepId;
+
+    @JsonProperty("step_index")
+    private final int stepIndex;
+
+    @JsonProperty("step_type")
+    private final String stepType;
+
+    @JsonProperty("checkpoint_type")
+    private final String checkpointType;
+
+    @JsonProperty("gate_decision")
+    private final String gateDecision;
+
+    @JsonProperty("gate_reason")
+    private final String gateReason;
+
+    @JsonProperty("is_resumable")
+    private final boolean resumable;
+
+    @JsonProperty("resume_count")
+    private final int resumeCount;
+
+    @JsonProperty("created_at")
+    private final String createdAt;
+
+    @JsonCreator
+    public Checkpoint(
+        @JsonProperty("id") long id,
+        @JsonProperty("workflow_id") String workflowId,
+        @JsonProperty("step_id") String stepId,
+        @JsonProperty("step_index") int stepIndex,
+        @JsonProperty("step_type") String stepType,
+        @JsonProperty("checkpoint_type") String checkpointType,
+        @JsonProperty("gate_decision") String gateDecision,
+        @JsonProperty("gate_reason") String gateReason,
+        @JsonProperty("is_resumable") boolean resumable,
+        @JsonProperty("resume_count") int resumeCount,
+        @JsonProperty("created_at") String createdAt) {
+      this.id = id;
+      this.workflowId = workflowId;
+      this.stepId = stepId;
+      this.stepIndex = stepIndex;
+      this.stepType = stepType;
+      this.checkpointType = checkpointType;
+      this.gateDecision = gateDecision;
+      this.gateReason = gateReason;
+      this.resumable = resumable;
+      this.resumeCount = resumeCount;
+      this.createdAt = createdAt;
+    }
+
+    public long getId() { return id; }
+    public String getWorkflowId() { return workflowId; }
+    public String getStepId() { return stepId; }
+    public int getStepIndex() { return stepIndex; }
+    public String getStepType() { return stepType; }
+    public String getCheckpointType() { return checkpointType; }
+    public String getGateDecision() { return gateDecision; }
+    public String getGateReason() { return gateReason; }
+    public boolean isResumable() { return resumable; }
+    public int getResumeCount() { return resumeCount; }
+    public String getCreatedAt() { return createdAt; }
+  }
+
+  /** Response from listing checkpoints. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static final class CheckpointListResponse {
+
+    @JsonProperty("checkpoints")
+    private final List<Checkpoint> checkpoints;
+
+    @JsonProperty("workflow_id")
+    private final String workflowId;
+
+    @JsonCreator
+    public CheckpointListResponse(
+        @JsonProperty("checkpoints") List<Checkpoint> checkpoints,
+        @JsonProperty("workflow_id") String workflowId) {
+      this.checkpoints = checkpoints != null
+          ? Collections.unmodifiableList(checkpoints)
+          : Collections.emptyList();
+      this.workflowId = workflowId;
+    }
+
+    public List<Checkpoint> getCheckpoints() { return checkpoints; }
+    public String getWorkflowId() { return workflowId; }
+  }
+
+  /** Response after resuming from a checkpoint. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static final class ResumeFromCheckpointResponse {
+
+    @JsonProperty("workflow_id")
+    private final String workflowId;
+
+    @JsonProperty("resumed_from_checkpoint")
+    private final String resumedFromCheckpoint;
+
+    @JsonProperty("resumed_from_index")
+    private final int resumedFromIndex;
+
+    @JsonProperty("new_decision")
+    private final String newDecision;
+
+    @JsonProperty("decision_source")
+    private final String decisionSource;
+
+    @JsonProperty("resume_count")
+    private final int resumeCount;
+
+    @JsonProperty("message")
+    private final String message;
+
+    @JsonCreator
+    public ResumeFromCheckpointResponse(
+        @JsonProperty("workflow_id") String workflowId,
+        @JsonProperty("resumed_from_checkpoint") String resumedFromCheckpoint,
+        @JsonProperty("resumed_from_index") int resumedFromIndex,
+        @JsonProperty("new_decision") String newDecision,
+        @JsonProperty("decision_source") String decisionSource,
+        @JsonProperty("resume_count") int resumeCount,
+        @JsonProperty("message") String message) {
+      this.workflowId = workflowId;
+      this.resumedFromCheckpoint = resumedFromCheckpoint;
+      this.resumedFromIndex = resumedFromIndex;
+      this.newDecision = newDecision;
+      this.decisionSource = decisionSource;
+      this.resumeCount = resumeCount;
+      this.message = message;
+    }
+
+    public String getWorkflowId() { return workflowId; }
+    public String getResumedFromCheckpoint() { return resumedFromCheckpoint; }
+    public int getResumedFromIndex() { return resumedFromIndex; }
+    public String getNewDecision() { return newDecision; }
+    public String getDecisionSource() { return decisionSource; }
+    public int getResumeCount() { return resumeCount; }
+    public String getMessage() { return message; }
+  }
+
   /** Information about a workflow step. */
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static final class WorkflowStepInfo {

--- a/src/test/java/com/getaxonflow/sdk/adapters/LangGraphAdapterTest.java
+++ b/src/test/java/com/getaxonflow/sdk/adapters/LangGraphAdapterTest.java
@@ -209,7 +209,9 @@ class LangGraphAdapterTest {
               Collections.emptyList(),
               "https://approve.me",
               null,
-              null);
+              null,
+              false,
+              "fresh");
       when(client.stepGate(anyString(), anyString(), any(StepGateRequest.class))).thenReturn(resp);
 
       assertThatThrownBy(() -> adapter.checkGate("deploy", "human_task"))
@@ -955,7 +957,7 @@ class LangGraphAdapterTest {
   private void mockStepGate(
       GateDecision decision, String stepId, String reason, List<String> policyIds) {
     StepGateResponse resp =
-        new StepGateResponse(decision, stepId, reason, policyIds, null, null, null);
+        new StepGateResponse(decision, stepId, reason, policyIds, null, null, null, false, "fresh");
     when(client.stepGate(anyString(), anyString(), any(StepGateRequest.class))).thenReturn(resp);
   }
 }


### PR DESCRIPTION
Adds RetryPolicy, Cached, DecisionSource to StepGateRequest/Response. Adds Checkpoint, CheckpointListResponse, ResumeFromCheckpointResponse types. Backward-compatible constructors preserved. All 1173 tests pass.