### PR TITLE
feat(config): add mapTimeout — Java SDK parity with TS/Python/Go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the AxonFlow Java SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.4.1] - 2026-04-20
+
+### Added
+
+- **`mapTimeout` field on `AxonFlowConfig`** — brings Java to parity with
+  the TypeScript, Python, and Go SDKs (all three already had a separate
+  MAP timeout). The shared `timeout` (default 60s) only covered single-
+  request endpoints; MAP plans routinely take 60-120s because they
+  chain multiple LLM calls end-to-end, and the global timeout was
+  cutting them off. New constant `DEFAULT_MAP_TIMEOUT = 120s`, new
+  builder method `AxonFlowConfig.builder().mapTimeout(Duration.ofSeconds(300))`,
+  and new environment variable `AXONFLOW_MAP_TIMEOUT_SECONDS`. All
+  plan-lifecycle methods (`generatePlan`, `executePlan`, `getPlanStatus`,
+  `updatePlan`, `cancelPlan`, `resumePlan`, `rollbackPlan`,
+  `getPlanVersions`) now use a plan-specific `OkHttpClient` clone with
+  `callTimeout` / `readTimeout` / `writeTimeout` set to `mapTimeout`.
+  Shares connection pool + interceptors + dispatcher with the main
+  client; only the timeout attributes differ. Keep `mapTimeout` ≤
+  server `AXONFLOW_MAP_MAX_TIMEOUT_SECONDS` (default 300s) ≤
+  front-door ALB `idle_timeout.timeout_seconds` (default 300s), or the
+  connection is killed mid-stream.
+
 ## [5.4.0] - 2026-04-18
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.getaxonflow</groupId>
     <artifactId>axonflow-sdk</artifactId>
-    <version>5.4.0</version>
+    <version>5.4.1</version>
     <packaging>jar</packaging>
 
     <name>AxonFlow Java SDK</name>

--- a/src/main/java/com/getaxonflow/sdk/AxonFlow.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlow.java
@@ -124,6 +124,17 @@ public final class AxonFlow implements Closeable {
 
   private final AxonFlowConfig config;
   private final OkHttpClient httpClient;
+
+  /**
+   * Clone of {@link #httpClient} with {@code callTimeout} overridden to {@code
+   * config.getMapTimeout()}. Used for every plan-lifecycle call (generate, execute, get, update,
+   * cancel, resume, rollback) where a single call may outlive the default request timeout. MAP
+   * plans chain multiple LLM calls end-to-end and commonly take 60-120s; the global timeout
+   * (default 60s) would cut them off. Shares the connection pool, interceptors, and dispatcher
+   * with {@link #httpClient} — only the call-timeout attribute differs.
+   */
+  private final OkHttpClient planHttpClient;
+
   private final ObjectMapper objectMapper;
   private final RetryExecutor retryExecutor;
   private final ResponseCache cache;
@@ -145,6 +156,13 @@ public final class AxonFlow implements Closeable {
     }
 
     this.httpClient = HttpClientFactory.create(config);
+    this.planHttpClient =
+        this.httpClient
+            .newBuilder()
+            .callTimeout(config.getMapTimeout().toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS)
+            .readTimeout(config.getMapTimeout().toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS)
+            .writeTimeout(config.getMapTimeout().toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS)
+            .build();
     this.objectMapper = createObjectMapper();
     this.retryExecutor = new RetryExecutor(config.getRetryConfig());
     this.cache = new ResponseCache(config.getCacheConfig());
@@ -1298,7 +1316,7 @@ public final class AxonFlow implements Closeable {
           agentRequest.put("context", Map.of("domain", domain));
 
           Request httpRequest = buildRequest("POST", "/api/request", agentRequest);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = planHttpClient.newCall(httpRequest).execute()) {
             return parsePlanResponse(response, request.getDomain());
           }
         },
@@ -1413,7 +1431,7 @@ public final class AxonFlow implements Closeable {
       agentRequest.put("context", Map.of("plan_id", planId));
 
       Request httpRequest = buildRequest("POST", "/api/request", agentRequest);
-      try (Response response = httpClient.newCall(httpRequest).execute()) {
+      try (Response response = planHttpClient.newCall(httpRequest).execute()) {
         return parseExecutePlanResponse(response, planId);
       }
     } catch (AxonFlowException e) {
@@ -1511,7 +1529,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildRequest("GET", "/api/v1/plan/" + planId, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = planHttpClient.newCall(httpRequest).execute()) {
             return parseResponse(response, PlanResponse.class);
           }
         },
@@ -1557,7 +1575,7 @@ public final class AxonFlow implements Closeable {
           agentRequest.put("context", context);
 
           Request httpRequest = buildRequest("POST", "/api/request", agentRequest);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = planHttpClient.newCall(httpRequest).execute()) {
             return parsePlanResponse(response, request.getDomain());
           }
         },
@@ -1584,7 +1602,7 @@ public final class AxonFlow implements Closeable {
           Request httpRequest =
               buildRequest(
                   "POST", "/api/v1/plan/" + planId + "/cancel", body.isEmpty() ? null : body);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = planHttpClient.newCall(httpRequest).execute()) {
             return parseResponse(response, CancelPlanResponse.class);
           }
         },
@@ -1620,7 +1638,7 @@ public final class AxonFlow implements Closeable {
       return retryExecutor.execute(
           () -> {
             Request httpRequest = buildRequest("PUT", "/api/v1/plan/" + planId, request);
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            try (Response response = planHttpClient.newCall(httpRequest).execute()) {
               return parseResponse(response, UpdatePlanResponse.class);
             }
           },
@@ -1645,7 +1663,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildRequest("GET", "/api/v1/plan/" + planId + "/versions", null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = planHttpClient.newCall(httpRequest).execute()) {
             return parseResponse(response, PlanVersionsResponse.class);
           }
         },
@@ -1668,7 +1686,7 @@ public final class AxonFlow implements Closeable {
           body.put("approved", approved != null ? approved : true);
 
           Request httpRequest = buildRequest("POST", "/api/v1/plan/" + planId + "/resume", body);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = planHttpClient.newCall(httpRequest).execute()) {
             return parseResponse(response, ResumePlanResponse.class);
           }
         },
@@ -1702,7 +1720,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildRequest("POST", "/api/v1/plan/" + planId + "/rollback/" + targetVersion, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = planHttpClient.newCall(httpRequest).execute()) {
             return parseResponse(response, RollbackPlanResponse.class);
           }
         },

--- a/src/main/java/com/getaxonflow/sdk/AxonFlowConfig.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlowConfig.java
@@ -76,6 +76,19 @@ public final class AxonFlowConfig {
   /** Default timeout for HTTP requests. */
   public static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(60);
 
+  /**
+   * Default timeout for MAP (Multi-Agent Planning) requests.
+   *
+   * <p>MAP plans chain several LLM calls end-to-end and routinely run longer than a single
+   * request — a 5-step plan at ~15s/step takes 60-75s by itself. 120s matches the TypeScript /
+   * Python / Go SDK defaults. Override per-client via {@link Builder#mapTimeout(Duration)} or
+   * {@code AXONFLOW_MAP_TIMEOUT_SECONDS}. The orchestrator's plan budget caps at {@code
+   * AXONFLOW_MAP_MAX_TIMEOUT_SECONDS} (default 300s); the front-door ALB's {@code
+   * idle_timeout.timeout_seconds} must be {@code >=} that cap or the connection is killed
+   * mid-stream. Keep these three knobs moving together.
+   */
+  public static final Duration DEFAULT_MAP_TIMEOUT = Duration.ofSeconds(120);
+
   /** Default endpoint URL. */
   public static final String DEFAULT_ENDPOINT = "http://localhost:8080";
 
@@ -87,6 +100,7 @@ public final class AxonFlowConfig {
   private final String clientSecret;
   private final Mode mode;
   private final Duration timeout;
+  private final Duration mapTimeout;
   private final boolean debug;
   private final boolean insecureSkipVerify;
   private final RetryConfig retryConfig;
@@ -105,6 +119,7 @@ public final class AxonFlowConfig {
     this.clientSecret = builder.clientSecret;
     this.mode = builder.mode != null ? builder.mode : Mode.PRODUCTION;
     this.timeout = builder.timeout != null ? builder.timeout : DEFAULT_TIMEOUT;
+    this.mapTimeout = builder.mapTimeout != null ? builder.mapTimeout : DEFAULT_MAP_TIMEOUT;
     this.debug = builder.debug;
     this.insecureSkipVerify = builder.insecureSkipVerify;
     this.retryConfig = builder.retryConfig != null ? builder.retryConfig : RetryConfig.defaults();
@@ -168,6 +183,7 @@ public final class AxonFlowConfig {
    *   <li>AXONFLOW_CLIENT_SECRET - The client secret
    *   <li>AXONFLOW_MODE - Operating mode (production/sandbox)
    *   <li>AXONFLOW_TIMEOUT_SECONDS - Request timeout in seconds
+   *   <li>AXONFLOW_MAP_TIMEOUT_SECONDS - MAP plan timeout in seconds (default 120)
    *   <li>AXONFLOW_DEBUG - Enable debug mode (true/false)
    * </ul>
    *
@@ -206,6 +222,15 @@ public final class AxonFlowConfig {
       }
     }
 
+    String mapTimeoutStr = System.getenv("AXONFLOW_MAP_TIMEOUT_SECONDS");
+    if (mapTimeoutStr != null && !mapTimeoutStr.isEmpty()) {
+      try {
+        builder.mapTimeout(Duration.ofSeconds(Long.parseLong(mapTimeoutStr)));
+      } catch (NumberFormatException e) {
+        // Ignore invalid timeout, use default
+      }
+    }
+
     String debugStr = System.getenv("AXONFLOW_DEBUG");
     if ("true".equalsIgnoreCase(debugStr)) {
       builder.debug(true);
@@ -232,6 +257,19 @@ public final class AxonFlowConfig {
 
   public Duration getTimeout() {
     return timeout;
+  }
+
+  /**
+   * Returns the timeout for MAP (Multi-Agent Planning) requests.
+   *
+   * <p>Applied per-call to plan-lifecycle methods: {@code generatePlan}, {@code executePlan},
+   * {@code getPlan}, {@code updatePlan}, {@code cancelPlan}, and {@code resumePlan}. Defaults to
+   * {@link #DEFAULT_MAP_TIMEOUT} (120s).
+   *
+   * @return the MAP request timeout
+   */
+  public Duration getMapTimeout() {
+    return mapTimeout;
   }
 
   public boolean isDebug() {
@@ -312,6 +350,7 @@ public final class AxonFlowConfig {
     private String clientSecret;
     private Mode mode;
     private Duration timeout;
+    private Duration mapTimeout;
     private boolean debug;
     private boolean insecureSkipVerify;
     private RetryConfig retryConfig;
@@ -391,6 +430,24 @@ public final class AxonFlowConfig {
      */
     public Builder timeout(Duration timeout) {
       this.timeout = timeout;
+      return this;
+    }
+
+    /**
+     * Sets the MAP (Multi-Agent Planning) request timeout.
+     *
+     * <p>Applied per-call to plan-lifecycle methods (generatePlan, executePlan, getPlan,
+     * updatePlan, cancelPlan, resumePlan). Defaults to 120s, matching the TS / Python / Go SDKs.
+     * Raise for long-running plans but keep the orchestrator ({@code
+     * AXONFLOW_MAP_MAX_TIMEOUT_SECONDS}, default 300s) and front-door ALB ({@code
+     * idle_timeout.timeout_seconds}, default 300s) tuned consistently or the connection is cut
+     * mid-stream.
+     *
+     * @param mapTimeout the MAP timeout duration
+     * @return this builder
+     */
+    public Builder mapTimeout(Duration mapTimeout) {
+      this.mapTimeout = mapTimeout;
       return this;
     }
 

--- a/src/test/java/com/getaxonflow/sdk/AxonFlowConfigTest.java
+++ b/src/test/java/com/getaxonflow/sdk/AxonFlowConfigTest.java
@@ -38,6 +38,25 @@ class AxonFlowConfigTest {
     assertThat(config.isLocalhost()).isTrue();
     assertThat(config.getMode()).isEqualTo(Mode.PRODUCTION);
     assertThat(config.getTimeout()).isEqualTo(AxonFlowConfig.DEFAULT_TIMEOUT);
+    // MAP timeout defaults to 120s — matches TS / Python / Go SDKs. The
+    // shared `timeout` is for single-request endpoints; MAP plans chain
+    // multiple LLM calls and need their own budget.
+    assertThat(config.getMapTimeout()).isEqualTo(AxonFlowConfig.DEFAULT_MAP_TIMEOUT);
+    assertThat(AxonFlowConfig.DEFAULT_MAP_TIMEOUT).isEqualTo(Duration.ofSeconds(120));
+  }
+
+  @Test
+  @DisplayName("should accept custom mapTimeout on builder")
+  void shouldAcceptCustomMapTimeout() {
+    AxonFlowConfig config =
+        AxonFlowConfig.builder()
+            .endpoint("http://localhost:8080")
+            .mapTimeout(Duration.ofSeconds(300))
+            .build();
+
+    assertThat(config.getMapTimeout()).isEqualTo(Duration.ofSeconds(300));
+    // Overriding mapTimeout does not affect the regular request timeout.
+    assertThat(config.getTimeout()).isEqualTo(AxonFlowConfig.DEFAULT_TIMEOUT);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Closes the Java side of axonflow-enterprise#1648. The Java SDK had a single shared `timeout` field (default 60s) while TypeScript, Python, and Go all already expose a separate `mapTimeout` (default 120s). MAP plans chain multiple LLM calls end-to-end and commonly take 60-120s; the 60s shared timeout was cutting them off mid-stream on long plans, which callers had to work around by bumping `timeout` platform-wide.

## Changes

- `DEFAULT_MAP_TIMEOUT = Duration.ofSeconds(120)` — matches TS/Python/Go defaults
- `mapTimeout` field + `getMapTimeout()` on `AxonFlowConfig`
- `AxonFlowConfig.Builder#mapTimeout(Duration)` setter
- `AXONFLOW_MAP_TIMEOUT_SECONDS` env var picked up by `fromEnvironment()`
- `planHttpClient` on `AxonFlow` — an `OkHttpClient` clone with `callTimeout` / `readTimeout` / `writeTimeout` set to `mapTimeout`. Shares the connection pool, interceptors, and dispatcher with the main client — only the timeout attributes differ.
- Nine plan-lifecycle call sites swapped to `planHttpClient.newCall(...)`: `generatePlan` (both overloads), `executePlan`, `getPlanStatus`, `updatePlan`, `cancelPlan`, `resumePlan`, `rollbackPlan`, `getPlanVersions`
- Unit tests for the default (120s) and builder override
- Version 5.4.0 → 5.4.1 (additive, backwards compatible)

## Alignment with server

Keep the three knobs moving together or long plans 504 mid-stream:

| Layer | Knob | Default |
|---|---|---|
| Java SDK | `mapTimeout` | 120s |
| Orchestrator | `AXONFLOW_MAP_MAX_TIMEOUT_SECONDS` | 300s |
| Front-door ALB | `idle_timeout.timeout_seconds` | 300s |

The SDK's `mapTimeout` must be ≤ the orchestrator cap, which must be ≤ the ALB idle timeout.

## Test plan

- [x] `mvn test -Dtest=AxonFlowConfigTest` green
- [x] New test: default `getMapTimeout()` = 120s
- [x] New test: builder `mapTimeout(300s)` overrides default, `getTimeout()` unaffected
- [ ] Integration test against local enterprise compose (deferred; platform-side env + CFN knob landing in axonflow-enterprise#1649)

## Related

- axonflow-enterprise#1648 (tracking issue)
- axonflow-enterprise#1643 (initial TS SDK `mapTimeout` + platform 300s cap)
- axonflow-enterprise#1649 (platform-side `AXONFLOW_MAP_MAX_TIMEOUT_SECONDS` env + `AlbIdleTimeoutSeconds` CFN parameter)