### PR TITLE
chore(version): bump to 5.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow Java SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.4.1] - 2026-04-20
+## [5.5.0] - 2026-04-20
 
 ### Added
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.getaxonflow</groupId>
     <artifactId>axonflow-sdk</artifactId>
-    <version>5.4.1</version>
+    <version>5.5.0</version>
     <packaging>jar</packaging>
 
     <name>AxonFlow Java SDK</name>


### PR DESCRIPTION
## Why

The `mapTimeout` field + builder method + `DEFAULT_MAP_TIMEOUT` constant added on `AxonFlowConfig` in #131 is an **additive public-API change**. Semver calls that MINOR, not PATCH.

The other three SDKs shipped the same feature as MINOR bumps:
- TypeScript: 5.4.0
- Python: 6.4.0
- Go: 5.4.0

Keeping Java on a patch bump (5.4.1) would be the inconsistent choice.

## Changes

- `pom.xml`: `5.4.1` → `5.5.0`
- `CHANGELOG.md`: section header retitled `## [5.4.1]` → `## [5.5.0]` (content unchanged)

No code change. Untagged — `5.4.1` was only on `main` via #131, no Maven Central release exists for it, so this is a clean retitle of the unreleased section.

## Follow-up

After merge, tag `v5.5.0` on `main` to trigger the Maven Central publish workflow.