### PR TITLE
feat(wcp): retry_context + idempotency_key (#1673 P1+P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to the AxonFlow Java SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`retry_context` and `idempotency_key` support on the step gate** —
+  `StepGateResponse` now carries a `RetryContext` object on every gate call with the
+  true `(workflow_id, step_id)` lifecycle: `gateCount`, `completionCount`,
+  `priorCompletionStatus` (`PriorCompletionStatus` enum —
+  `NONE` / `COMPLETED` / `GATED_NOT_COMPLETED`), `priorOutputAvailable`,
+  `priorOutput`, `priorCompletionAt`, `firstAttemptAt`, `lastAttemptAt`,
+  `lastDecision`, and `idempotencyKey`. Prefer these to the legacy `cached` /
+  `decisionSource` fields.
+- **`stepGate(workflowId, stepId, request, options)` overload** — new 4-arg overload
+  taking `StepGateOptions`. Use `StepGateOptions.includePriorOutput()` to send
+  `?include_prior_output=true` so `retryContext.priorOutput` is populated when a prior
+  `/complete` has landed. Existing 3-arg overload keeps its signature and delegates
+  with `StepGateOptions.defaults()`.
+- **`StepGateRequest.idempotencyKey`** — caller-supplied opaque business-level key
+  (max 255 chars; validated at construction). Immutable once recorded on the first gate
+  call for a `(workflow, step)`; subsequent gate/complete calls must pass the same key.
+- **`MarkStepCompletedRequest.idempotencyKey`** — must match the key set on the
+  corresponding gate call, if any. Mismatch (including missing-vs-set on either side)
+  surfaces as a typed `IdempotencyKeyMismatchException`.
+- **`IdempotencyKeyMismatchException`** — new typed exception in
+  `com.getaxonflow.sdk.exceptions`. Thrown by `stepGate` and `markStepCompleted` when
+  the platform returns HTTP 409 with `error.code == "IDEMPOTENCY_KEY_MISMATCH"`.
+  Surfaces `workflowId`, `stepId`, `expectedIdempotencyKey`, `receivedIdempotencyKey`,
+  plus inherited `statusCode=409` and `errorCode="IDEMPOTENCY_KEY_MISMATCH"`.
+- **`RetryContext`, `PriorCompletionStatus`, `StepGateOptions`** — exported in
+  `WorkflowTypes`.
+
+### Fixed
+
+- **409 dispatch on step gate/complete** — previously all 409 responses on
+  `markStepCompleted` fell through to a generic `AxonFlowException(..., 409,
+  "VERSION_CONFLICT")`, conflating step idempotency conflicts with plan version
+  conflicts. The step gate/complete call sites now inspect the 409 body and dispatch
+  to `IdempotencyKeyMismatchException` when `error.code` matches, falling back to a
+  generic `AxonFlowException` otherwise. Plan update paths (which also use 409) are
+  untouched.
+
+### Deprecated
+
+- **`StepGateResponse.isCached()`** and **`StepGateResponse.getDecisionSource()`** —
+  marked `@Deprecated`. Use `getRetryContext().getGateCount() > 1` and
+  `getRetryContext().getPriorCompletionStatus()` instead. Planned for removal in a
+  future major version.
+
+### Compatibility
+
+Companion to the platform change that introduces `retry_context` on
+`POST /api/v1/workflows/{workflow_id}/steps/{step_id}/gate`. Additive only — existing
+callers that never set `idempotencyKey` or pass `StepGateOptions` see no behavior
+change. Binary-compatibility preserved: old `StepGateRequest`, `StepGateResponse`, and
+`MarkStepCompletedRequest` constructors kept alongside new ones.
+
 ## [5.5.0] - 2026-04-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow Java SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [5.6.0] - 2026-04-21
 
 ### Added
 

--- a/examples/wcp-retry-idempotency/.gitignore
+++ b/examples/wcp-retry-idempotency/.gitignore
@@ -1,0 +1,2 @@
+target/
+*.class

--- a/examples/wcp-retry-idempotency/pom.xml
+++ b/examples/wcp-retry-idempotency/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.getaxonflow.examples</groupId>
+    <artifactId>wcp-retry-idempotency</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>WCP retry_context + idempotency_key E2E Example</name>
+    <description>
+        E2E validation of #1673 Phase 1 + Phase 2 through the Java SDK.
+    </description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.getaxonflow</groupId>
+            <artifactId>axonflow-sdk</artifactId>
+            <version>5.5.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.getaxonflow.examples.WcpRetryIdempotency</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/wcp-retry-idempotency/src/main/java/com/getaxonflow/examples/WcpRetryIdempotency.java
+++ b/examples/wcp-retry-idempotency/src/main/java/com/getaxonflow/examples/WcpRetryIdempotency.java
@@ -1,0 +1,233 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: Apache-2.0
+//
+// WCP retry_context + idempotency_key E2E example (Issue #1673 Phase 1 + 2).
+//
+// Exercises the new Java SDK surface end-to-end against a running v7.3.0
+// enterprise stack. Every assertion fails the process with System.exit(1).
+//
+// Run from this directory:
+//   mvn install -DskipTests=true       # from the SDK root, first time only
+//   source /tmp/axonflow-e2e-env.sh
+//   export AXONFLOW_BASE_URL=http://localhost:8080
+//   mvn -q compile exec:java
+package com.getaxonflow.examples;
+
+import com.getaxonflow.sdk.AxonFlow;
+import com.getaxonflow.sdk.AxonFlowConfig;
+import com.getaxonflow.sdk.exceptions.IdempotencyKeyMismatchException;
+import com.getaxonflow.sdk.types.workflow.WorkflowTypes;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class WcpRetryIdempotency {
+
+    public static void main(String[] args) {
+        String endpoint = envOrDefault("AXONFLOW_BASE_URL", "http://localhost:8080");
+        String clientId = mustEnv("AXONFLOW_CLIENT_ID");
+        String clientSecret = mustEnv("AXONFLOW_CLIENT_SECRET");
+
+        AxonFlow client = AxonFlow.create(
+                AxonFlowConfig.builder()
+                        .endpoint(endpoint)
+                        .clientId(clientId)
+                        .clientSecret(clientSecret)
+                        .build());
+
+        banner("Act 1 — retry_context (Java SDK)");
+        act1(client);
+
+        banner("Act 2 — idempotency_key (Java SDK)");
+        act2(client);
+
+        banner("All assertions passed ✔");
+    }
+
+    private static void act1(AxonFlow client) {
+        WorkflowTypes.CreateWorkflowResponse wf = client.createWorkflow(
+                WorkflowTypes.CreateWorkflowRequest.builder()
+                        .workflowName("java-sdk-retry-context")
+                        .build());
+        System.out.println("workflow: " + wf.getWorkflowId());
+
+        // 1) First gate — first-call invariants
+        WorkflowTypes.StepGateResponse first = client.stepGate(
+                wf.getWorkflowId(),
+                "step-1",
+                WorkflowTypes.StepGateRequest.builder()
+                        .stepName("first-step")
+                        .stepType(WorkflowTypes.StepType.TOOL_CALL)
+                        .build());
+        WorkflowTypes.RetryContext rc = first.getRetryContext();
+        assertTrue("retry_context not null", rc != null);
+        assertEqInt("first gate_count", 1, rc.getGateCount());
+        assertEqInt("first completion_count", 0, rc.getCompletionCount());
+        assertEqStr("first prior_completion_status",
+                WorkflowTypes.PriorCompletionStatus.NONE.name(),
+                rc.getPriorCompletionStatus().name());
+        assertTrue("first !prior_output_available", !rc.isPriorOutputAvailable());
+        assertEqStr("first last_decision (first-call invariant)",
+                first.getDecision().name(), rc.getLastDecision().name());
+        assertTrue("first FirstAttemptAt == LastAttemptAt",
+                rc.getFirstAttemptAt().equals(rc.getLastAttemptAt()));
+        System.out.println("  first gate invariants ✔");
+
+        // 2) Complete, then re-gate
+        Map<String, Object> output = new HashMap<>();
+        output.put("transfer_id", "TXN-java-1");
+        output.put("amount", 500);
+        client.markStepCompleted(
+                wf.getWorkflowId(),
+                "step-1",
+                WorkflowTypes.MarkStepCompletedRequest.builder().output(output).build());
+        WorkflowTypes.StepGateResponse reGate = client.stepGate(
+                wf.getWorkflowId(),
+                "step-1",
+                WorkflowTypes.StepGateRequest.builder()
+                        .stepType(WorkflowTypes.StepType.TOOL_CALL)
+                        .build());
+        assertEqInt("re-gate post-complete gate_count", 2,
+                reGate.getRetryContext().getGateCount());
+        assertEqInt("re-gate post-complete completion_count", 1,
+                reGate.getRetryContext().getCompletionCount());
+        assertEqStr("re-gate post-complete prior_completion_status",
+                WorkflowTypes.PriorCompletionStatus.COMPLETED.name(),
+                reGate.getRetryContext().getPriorCompletionStatus().name());
+        assertTrue("re-gate post-complete prior_output_available",
+                reGate.getRetryContext().isPriorOutputAvailable());
+        assertTrue("re-gate post-complete prior_output omitted by default",
+                reGate.getRetryContext().getPriorOutput() == null);
+        assertTrue("re-gate post-complete cached==true", reGate.isCached());
+        System.out.println("  re-gate post-complete ✔");
+
+        // 3) Gate on step-2 without completion (agent-crash simulation)
+        client.stepGate(
+                wf.getWorkflowId(),
+                "step-2",
+                WorkflowTypes.StepGateRequest.builder()
+                        .stepName("second-step")
+                        .stepType(WorkflowTypes.StepType.TOOL_CALL)
+                        .build());
+        WorkflowTypes.StepGateResponse reGate2 = client.stepGate(
+                wf.getWorkflowId(),
+                "step-2",
+                WorkflowTypes.StepGateRequest.builder()
+                        .stepType(WorkflowTypes.StepType.TOOL_CALL)
+                        .build());
+        assertEqStr("gated_not_completed status",
+                WorkflowTypes.PriorCompletionStatus.GATED_NOT_COMPLETED.name(),
+                reGate2.getRetryContext().getPriorCompletionStatus().name());
+        assertEqInt("gated_not_completed completion_count", 0,
+                reGate2.getRetryContext().getCompletionCount());
+        System.out.println("  gated_not_completed ✔");
+
+        // 4) include_prior_output=true recovers the payload
+        WorkflowTypes.StepGateResponse withPrior = client.stepGate(
+                wf.getWorkflowId(),
+                "step-1",
+                WorkflowTypes.StepGateRequest.builder()
+                        .stepType(WorkflowTypes.StepType.TOOL_CALL)
+                        .build(),
+                WorkflowTypes.StepGateOptions.includePriorOutput());
+        assertTrue("prior_output populated",
+                withPrior.getRetryContext().getPriorOutput() != null);
+        assertEqStr("prior_output[transfer_id]", "TXN-java-1",
+                String.valueOf(withPrior.getRetryContext().getPriorOutput().get("transfer_id")));
+        System.out.println("  prior_output recovery ✔");
+    }
+
+    private static void act2(AxonFlow client) {
+        WorkflowTypes.CreateWorkflowResponse wf = client.createWorkflow(
+                WorkflowTypes.CreateWorkflowRequest.builder()
+                        .workflowName("java-sdk-idempotency-key")
+                        .build());
+        System.out.println("workflow: " + wf.getWorkflowId());
+
+        String originalKey = "payment:wire:java-sdk-invoice-1";
+
+        // 5) Gate with key — retry_context.idempotency_key echoes
+        WorkflowTypes.StepGateResponse first = client.stepGate(
+                wf.getWorkflowId(),
+                "step-1",
+                WorkflowTypes.StepGateRequest.builder()
+                        .stepName("wire")
+                        .stepType(WorkflowTypes.StepType.TOOL_CALL)
+                        .idempotencyKey(originalKey)
+                        .build());
+        assertEqStr("retry_context.idempotency_key echo",
+                originalKey, first.getRetryContext().getIdempotencyKey());
+        System.out.println("  key round-trip ✔");
+
+        // 6) Re-gate with different key → IdempotencyKeyMismatchException
+        try {
+            client.stepGate(
+                    wf.getWorkflowId(),
+                    "step-1",
+                    WorkflowTypes.StepGateRequest.builder()
+                            .stepType(WorkflowTypes.StepType.TOOL_CALL)
+                            .idempotencyKey("payment:wire:different-2")
+                            .build());
+            fail("expected IdempotencyKeyMismatchException on gate with different key");
+        } catch (IdempotencyKeyMismatchException e) {
+            assertEqStr("mismatch expected_key", originalKey, e.getExpectedIdempotencyKey());
+            assertEqStr("mismatch received_key", "payment:wire:different-2",
+                    e.getReceivedIdempotencyKey());
+            assertTrue("mismatch workflow_id populated",
+                    e.getWorkflowId() != null && e.getWorkflowId().startsWith("wf_"));
+            assertEqStr("mismatch step_id", "step-1", e.getStepId());
+        }
+        System.out.println("  typed 409 error ✔");
+
+        // 7) Complete with matching key
+        Map<String, Object> output = new HashMap<>();
+        output.put("transfer_id", "TXN-K1");
+        client.markStepCompleted(
+                wf.getWorkflowId(),
+                "step-1",
+                WorkflowTypes.MarkStepCompletedRequest.builder()
+                        .output(output)
+                        .idempotencyKey(originalKey)
+                        .build());
+        System.out.println("  complete with matching key ✔");
+    }
+
+    // --- helpers ---
+
+    private static String envOrDefault(String name, String fallback) {
+        String v = System.getenv(name);
+        return v == null || v.isEmpty() ? fallback : v;
+    }
+
+    private static String mustEnv(String name) {
+        String v = System.getenv(name);
+        if (v == null || v.isEmpty()) {
+            fail("missing env: " + name);
+        }
+        return v;
+    }
+
+    private static void assertTrue(String label, boolean cond) {
+        if (!cond) fail("assertion failed: " + label);
+    }
+
+    private static void assertEqStr(String label, String want, String got) {
+        if (want == null ? got != null : !want.equals(got)) {
+            fail(label + ": want \"" + want + "\", got \"" + got + "\"");
+        }
+    }
+
+    private static void assertEqInt(String label, int want, int got) {
+        if (want != got) fail(label + ": want " + want + ", got " + got);
+    }
+
+    private static void fail(String msg) {
+        System.err.println("FAIL: " + msg);
+        System.exit(1);
+    }
+
+    private static void banner(String s) {
+        System.out.println();
+        System.out.println("━━━ " + s + " ━━━");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.getaxonflow</groupId>
     <artifactId>axonflow-sdk</artifactId>
-    <version>5.5.0</version>
+    <version>5.6.0</version>
     <packaging>jar</packaging>
 
     <name>AxonFlow Java SDK</name>

--- a/src/main/java/com/getaxonflow/sdk/AxonFlow.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlow.java
@@ -5010,18 +5010,53 @@ public final class AxonFlow implements Closeable {
       String workflowId,
       String stepId,
       com.getaxonflow.sdk.types.workflow.WorkflowTypes.StepGateRequest request) {
+    return stepGate(
+        workflowId,
+        stepId,
+        request,
+        com.getaxonflow.sdk.types.workflow.WorkflowTypes.StepGateOptions.defaults());
+  }
+
+  /**
+   * Checks if a workflow step is allowed to proceed, with call-level options.
+   *
+   * <p>Pass {@link
+   * com.getaxonflow.sdk.types.workflow.WorkflowTypes.StepGateOptions#includePriorOutput()} to send
+   * {@code ?include_prior_output=true} so the response's {@code retry_context.prior_output} is
+   * populated when a prior /complete has landed.
+   *
+   * @param workflowId workflow ID
+   * @param stepId step ID
+   * @param request step gate request
+   * @param options call-level options (e.g. {@code includePriorOutput})
+   * @return the step gate response
+   * @throws IdempotencyKeyMismatchException if {@code request.idempotencyKey} conflicts with the
+   *     key recorded on an earlier gate call for this (workflow, step)
+   * @since 5.6.0
+   */
+  public com.getaxonflow.sdk.types.workflow.WorkflowTypes.StepGateResponse stepGate(
+      String workflowId,
+      String stepId,
+      com.getaxonflow.sdk.types.workflow.WorkflowTypes.StepGateRequest request,
+      com.getaxonflow.sdk.types.workflow.WorkflowTypes.StepGateOptions options) {
     Objects.requireNonNull(workflowId, "workflowId cannot be null");
     Objects.requireNonNull(stepId, "stepId cannot be null");
     Objects.requireNonNull(request, "request cannot be null");
+    Objects.requireNonNull(options, "options cannot be null");
+
+    String path = "/api/v1/workflows/" + workflowId + "/steps/" + stepId + "/gate";
+    if (options.isIncludePriorOutput()) {
+      path += "?include_prior_output=true";
+    }
+    final String fullPath = path;
 
     return retryExecutor.execute(
         () -> {
-          Request httpRequest =
-              buildOrchestratorRequest(
-                  "POST",
-                  "/api/v1/workflows/" + workflowId + "/steps/" + stepId + "/gate",
-                  request);
+          Request httpRequest = buildOrchestratorRequest("POST", fullPath, request);
           try (Response response = httpClient.newCall(httpRequest).execute()) {
+            if (response.code() == 409) {
+              throw toIdempotencyOrGeneric409(response, workflowId, stepId);
+            }
             return parseResponse(
                 response,
                 new TypeReference<
@@ -5055,6 +5090,9 @@ public final class AxonFlow implements Closeable {
                   "/api/v1/workflows/" + workflowId + "/steps/" + stepId + "/complete",
                   request != null ? request : Collections.emptyMap());
           try (Response response = httpClient.newCall(httpRequest).execute()) {
+            if (response.code() == 409) {
+              throw toIdempotencyOrGeneric409(response, workflowId, stepId);
+            }
             if (!response.isSuccessful()) {
               handleErrorResponse(response);
             }
@@ -5062,6 +5100,39 @@ public final class AxonFlow implements Closeable {
           }
         },
         "markStepCompleted");
+  }
+
+  /**
+   * Inspects a 409 response on a step gate/complete call. If the body carries {@code
+   * error.code == "IDEMPOTENCY_KEY_MISMATCH"}, returns a typed {@link
+   * IdempotencyKeyMismatchException}; otherwise falls back to a generic {@link AxonFlowException}.
+   *
+   * <p>Must only be called on responses with {@code response.code() == 409}. Consumes the response
+   * body.
+   */
+  private AxonFlowException toIdempotencyOrGeneric409(
+      Response response, String workflowId, String stepId) throws IOException {
+    String body = response.body() != null ? response.body().string() : "";
+    if (!body.isEmpty()) {
+      try {
+        JsonNode root = objectMapper.readTree(body);
+        JsonNode err = root.path("error");
+        if (err.path("code").asText("").equals("IDEMPOTENCY_KEY_MISMATCH")) {
+          JsonNode details = err.path("details");
+          String msg = err.path("message").asText("idempotency_key mismatch");
+          String detailsWorkflowId = details.path("workflow_id").asText(workflowId);
+          String detailsStepId = details.path("step_id").asText(stepId);
+          String expected = details.path("expected_idempotency_key").asText("");
+          String received = details.path("received_idempotency_key").asText("");
+          return new IdempotencyKeyMismatchException(
+              msg, detailsWorkflowId, detailsStepId, expected, received);
+        }
+      } catch (IOException ignored) {
+        // Fall through to generic 409 handling
+      }
+    }
+    String fallback = body.isEmpty() ? response.message() : body;
+    return new AxonFlowException(fallback, 409, null);
   }
 
   /**

--- a/src/main/java/com/getaxonflow/sdk/exceptions/IdempotencyKeyMismatchException.java
+++ b/src/main/java/com/getaxonflow/sdk/exceptions/IdempotencyKeyMismatchException.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.sdk.exceptions;
+
+/**
+ * Thrown when an {@code idempotency_key} on a step gate or complete call conflicts with the key
+ * recorded on an earlier gate call for the same {@code (workflow_id, step_id)} (HTTP 409).
+ *
+ * <p>Maps to HTTP 409 with {@code error.code == "IDEMPOTENCY_KEY_MISMATCH"}.
+ *
+ * <p>{@link #getExpectedIdempotencyKey()} is the empty string {@code ""} when the gate call had no
+ * key but complete did; conversely {@link #getReceivedIdempotencyKey()} is {@code ""} when complete
+ * omitted a key that gate had set.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * try {
+ *     axonflow.markStepCompleted(workflowId, stepId,
+ *         MarkStepCompletedRequest.builder().idempotencyKey("k2").build());
+ * } catch (IdempotencyKeyMismatchException e) {
+ *     System.out.println("expected=" + e.getExpectedIdempotencyKey()
+ *         + " received=" + e.getReceivedIdempotencyKey());
+ * }
+ * }</pre>
+ */
+public class IdempotencyKeyMismatchException extends AxonFlowException {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String workflowId;
+  private final String stepId;
+  private final String expectedIdempotencyKey;
+  private final String receivedIdempotencyKey;
+
+  /**
+   * Creates a new IdempotencyKeyMismatchException.
+   *
+   * @param message the error message from the platform
+   * @param workflowId the workflow ID where the mismatch occurred
+   * @param stepId the step ID where the mismatch occurred
+   * @param expectedIdempotencyKey the key recorded on the first gate call, or "" if none was set
+   * @param receivedIdempotencyKey the key supplied on the current request, or "" if none was set
+   */
+  public IdempotencyKeyMismatchException(
+      String message,
+      String workflowId,
+      String stepId,
+      String expectedIdempotencyKey,
+      String receivedIdempotencyKey) {
+    super(message, 409, "IDEMPOTENCY_KEY_MISMATCH");
+    this.workflowId = workflowId;
+    this.stepId = stepId;
+    this.expectedIdempotencyKey = expectedIdempotencyKey;
+    this.receivedIdempotencyKey = receivedIdempotencyKey;
+  }
+
+  /** Returns the workflow ID where the mismatch occurred. */
+  public String getWorkflowId() {
+    return workflowId;
+  }
+
+  /** Returns the step ID where the mismatch occurred. */
+  public String getStepId() {
+    return stepId;
+  }
+
+  /**
+   * Returns the key recorded on the first gate call for this (workflow, step), or the empty string
+   * if gate was called without a key.
+   */
+  public String getExpectedIdempotencyKey() {
+    return expectedIdempotencyKey;
+  }
+
+  /**
+   * Returns the key supplied on the current request that triggered the mismatch, or the empty
+   * string if the current request omitted a key.
+   */
+  public String getReceivedIdempotencyKey() {
+    return receivedIdempotencyKey;
+  }
+}

--- a/src/main/java/com/getaxonflow/sdk/types/workflow/WorkflowTypes.java
+++ b/src/main/java/com/getaxonflow/sdk/types/workflow/WorkflowTypes.java
@@ -438,6 +438,7 @@ public final class WorkflowTypes {
 
   /** Request to check if a step is allowed to proceed. */
   @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   public static final class StepGateRequest {
 
     @JsonProperty("step_name")
@@ -461,6 +462,9 @@ public final class WorkflowTypes {
     @JsonProperty("retry_policy")
     private final String retryPolicy;
 
+    @JsonProperty("idempotency_key")
+    private final String idempotencyKey;
+
     /** Backward-compatible constructor without toolContext or retryPolicy. */
     public StepGateRequest(
         String stepName,
@@ -468,7 +472,7 @@ public final class WorkflowTypes {
         Map<String, Object> stepInput,
         String model,
         String provider) {
-      this(stepName, stepType, stepInput, model, provider, null, null);
+      this(stepName, stepType, stepInput, model, provider, null, null, null);
     }
 
     /** Backward-compatible constructor without retryPolicy. */
@@ -479,7 +483,19 @@ public final class WorkflowTypes {
         String model,
         String provider,
         ToolContext toolContext) {
-      this(stepName, stepType, stepInput, model, provider, toolContext, null);
+      this(stepName, stepType, stepInput, model, provider, toolContext, null, null);
+    }
+
+    /** Backward-compatible constructor without idempotencyKey (pre-5.6). */
+    public StepGateRequest(
+        String stepName,
+        StepType stepType,
+        Map<String, Object> stepInput,
+        String model,
+        String provider,
+        ToolContext toolContext,
+        String retryPolicy) {
+      this(stepName, stepType, stepInput, model, provider, toolContext, retryPolicy, null);
     }
 
     @JsonCreator
@@ -490,7 +506,8 @@ public final class WorkflowTypes {
         @JsonProperty("model") String model,
         @JsonProperty("provider") String provider,
         @JsonProperty("tool_context") ToolContext toolContext,
-        @JsonProperty("retry_policy") String retryPolicy) {
+        @JsonProperty("retry_policy") String retryPolicy,
+        @JsonProperty("idempotency_key") String idempotencyKey) {
       this.stepName = stepName;
       this.stepType = Objects.requireNonNull(stepType, "stepType is required");
       this.stepInput =
@@ -499,6 +516,10 @@ public final class WorkflowTypes {
       this.provider = provider;
       this.toolContext = toolContext;
       this.retryPolicy = retryPolicy;
+      if (idempotencyKey != null && idempotencyKey.length() > 255) {
+        throw new IllegalArgumentException("idempotencyKey must be at most 255 characters");
+      }
+      this.idempotencyKey = idempotencyKey;
     }
 
     public String getStepName() {
@@ -533,6 +554,19 @@ public final class WorkflowTypes {
       return retryPolicy;
     }
 
+    /**
+     * Returns the caller-supplied idempotency key, or {@code null} if none was set.
+     *
+     * <p>Once recorded on the first gate call for a {@code (workflow_id, step_id)}, the key is
+     * immutable — subsequent gate/complete calls must pass the same key or raise
+     * {@code IdempotencyKeyMismatchException}.
+     *
+     * @return the idempotency key, or null
+     */
+    public String getIdempotencyKey() {
+      return idempotencyKey;
+    }
+
     public static Builder builder() {
       return new Builder();
     }
@@ -545,6 +579,7 @@ public final class WorkflowTypes {
       private String provider;
       private ToolContext toolContext;
       private String retryPolicy;
+      private String idempotencyKey;
 
       public Builder stepName(String stepName) {
         this.stepName = stepName;
@@ -582,10 +617,188 @@ public final class WorkflowTypes {
         return this;
       }
 
+      /**
+       * Set the caller-supplied idempotency key (max 255 chars). Once set on the first gate call
+       * for a (workflow, step), it is immutable on all subsequent gate and complete calls.
+       */
+      public Builder idempotencyKey(String idempotencyKey) {
+        this.idempotencyKey = idempotencyKey;
+        return this;
+      }
+
       public StepGateRequest build() {
         return new StepGateRequest(
-            stepName, stepType, stepInput, model, provider, toolContext, retryPolicy);
+            stepName,
+            stepType,
+            stepInput,
+            model,
+            provider,
+            toolContext,
+            retryPolicy,
+            idempotencyKey);
       }
+    }
+  }
+
+  /**
+   * State of the prior gate+complete cycle for a step.
+   *
+   * <p>See WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md §3.
+   */
+  public enum PriorCompletionStatus {
+    /** First gate call, no prior gates on this step. */
+    @JsonProperty("none")
+    NONE("none"),
+    /** A prior gate call and a prior /complete both landed for this (workflow, step). */
+    @JsonProperty("completed")
+    COMPLETED("completed"),
+    /** A prior gate landed but no /complete has followed for this (workflow, step). */
+    @JsonProperty("gated_not_completed")
+    GATED_NOT_COMPLETED("gated_not_completed");
+
+    private final String value;
+
+    PriorCompletionStatus(String value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+      return value;
+    }
+
+    @JsonCreator
+    public static PriorCompletionStatus fromValue(String value) {
+      for (PriorCompletionStatus status : values()) {
+        if (status.value.equals(value)) {
+          return status;
+        }
+      }
+      throw new IllegalArgumentException("Unknown prior completion status: " + value);
+    }
+  }
+
+  /**
+   * First-class state signal returned on every {@link StepGateResponse}.
+   *
+   * <p>Replaces the ambiguous {@code cached: bool} field. Prefer these fields to
+   * {@link StepGateResponse#isCached()} and {@link StepGateResponse#getDecisionSource()}.
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static final class RetryContext {
+
+    @JsonProperty("gate_count")
+    private final int gateCount;
+
+    @JsonProperty("completion_count")
+    private final int completionCount;
+
+    @JsonProperty("prior_completion_status")
+    private final PriorCompletionStatus priorCompletionStatus;
+
+    @JsonProperty("prior_output_available")
+    private final boolean priorOutputAvailable;
+
+    @JsonProperty("prior_output")
+    private final Map<String, Object> priorOutput;
+
+    @JsonProperty("prior_completion_at")
+    private final Instant priorCompletionAt;
+
+    @JsonProperty("first_attempt_at")
+    private final Instant firstAttemptAt;
+
+    @JsonProperty("last_attempt_at")
+    private final Instant lastAttemptAt;
+
+    @JsonProperty("last_decision")
+    private final GateDecision lastDecision;
+
+    @JsonProperty("idempotency_key")
+    private final String idempotencyKey;
+
+    @JsonCreator
+    public RetryContext(
+        @JsonProperty("gate_count") int gateCount,
+        @JsonProperty("completion_count") int completionCount,
+        @JsonProperty("prior_completion_status") PriorCompletionStatus priorCompletionStatus,
+        @JsonProperty("prior_output_available") boolean priorOutputAvailable,
+        @JsonProperty("prior_output") Map<String, Object> priorOutput,
+        @JsonProperty("prior_completion_at") Instant priorCompletionAt,
+        @JsonProperty("first_attempt_at") Instant firstAttemptAt,
+        @JsonProperty("last_attempt_at") Instant lastAttemptAt,
+        @JsonProperty("last_decision") GateDecision lastDecision,
+        @JsonProperty("idempotency_key") String idempotencyKey) {
+      this.gateCount = gateCount;
+      this.completionCount = completionCount;
+      this.priorCompletionStatus = priorCompletionStatus;
+      this.priorOutputAvailable = priorOutputAvailable;
+      this.priorOutput =
+          priorOutput != null ? Collections.unmodifiableMap(priorOutput) : null;
+      this.priorCompletionAt = priorCompletionAt;
+      this.firstAttemptAt = firstAttemptAt;
+      this.lastAttemptAt = lastAttemptAt;
+      this.lastDecision = lastDecision;
+      this.idempotencyKey = idempotencyKey != null ? idempotencyKey : "";
+    }
+
+    /** Number of /gate calls for this (workflow, step), including the current call. Always &gt;= 1. */
+    public int getGateCount() {
+      return gateCount;
+    }
+
+    /** Number of successful /complete calls for this (workflow, step). */
+    public int getCompletionCount() {
+      return completionCount;
+    }
+
+    /** Whether a prior gate+complete cycle has landed. */
+    public PriorCompletionStatus getPriorCompletionStatus() {
+      return priorCompletionStatus;
+    }
+
+    /** {@code true} iff {@link #getPriorCompletionStatus()} == COMPLETED. */
+    public boolean isPriorOutputAvailable() {
+      return priorOutputAvailable;
+    }
+
+    /**
+     * Output from the prior /complete, or {@code null}. Non-null only when the gate call was made
+     * with {@code includePriorOutput=true} AND a prior /complete has landed.
+     */
+    public Map<String, Object> getPriorOutput() {
+      return priorOutput;
+    }
+
+    /** Timestamp of the prior /complete, or {@code null}. */
+    public Instant getPriorCompletionAt() {
+      return priorCompletionAt;
+    }
+
+    /** Timestamp of the first gate call for this (workflow, step). */
+    public Instant getFirstAttemptAt() {
+      return firstAttemptAt;
+    }
+
+    /** Timestamp of the current gate call. */
+    public Instant getLastAttemptAt() {
+      return lastAttemptAt;
+    }
+
+    /**
+     * Decision of the immediately prior gate call. On first call, equals the current call's
+     * {@code decision}.
+     */
+    public GateDecision getLastDecision() {
+      return lastDecision;
+    }
+
+    /**
+     * The key the caller set on this step (from the first gate call that supplied one), or the
+     * empty string {@code ""} if the caller never supplied one. Once set, immutable.
+     */
+    public String getIdempotencyKey() {
+      return idempotencyKey;
     }
   }
 
@@ -620,6 +833,33 @@ public final class WorkflowTypes {
     @JsonProperty("decision_source")
     private final String decisionSource;
 
+    @JsonProperty("retry_context")
+    private final RetryContext retryContext;
+
+    /** Pre-5.6 constructor without retryContext (kept for binary compatibility). */
+    public StepGateResponse(
+        GateDecision decision,
+        String stepId,
+        String reason,
+        List<String> policyIds,
+        String approvalUrl,
+        List<PolicyMatch> policiesEvaluated,
+        List<PolicyMatch> policiesMatched,
+        boolean cached,
+        String decisionSource) {
+      this(
+          decision,
+          stepId,
+          reason,
+          policyIds,
+          approvalUrl,
+          policiesEvaluated,
+          policiesMatched,
+          cached,
+          decisionSource,
+          null);
+    }
+
     @JsonCreator
     public StepGateResponse(
         @JsonProperty("decision") GateDecision decision,
@@ -630,7 +870,8 @@ public final class WorkflowTypes {
         @JsonProperty("policies_evaluated") List<PolicyMatch> policiesEvaluated,
         @JsonProperty("policies_matched") List<PolicyMatch> policiesMatched,
         @JsonProperty("cached") boolean cached,
-        @JsonProperty("decision_source") String decisionSource) {
+        @JsonProperty("decision_source") String decisionSource,
+        @JsonProperty("retry_context") RetryContext retryContext) {
       this.decision = decision;
       this.stepId = stepId;
       this.reason = reason;
@@ -647,6 +888,7 @@ public final class WorkflowTypes {
               : Collections.emptyList();
       this.cached = cached;
       this.decisionSource = decisionSource;
+      this.retryContext = retryContext;
     }
 
     public GateDecision getDecision() {
@@ -691,16 +933,35 @@ public final class WorkflowTypes {
 
     /**
      * Returns whether this response was served from a prior decision rather than a fresh evaluation.
+     *
+     * @deprecated Use {@code getRetryContext().getGateCount() > 1} instead. Will be removed in a
+     *     future major version.
      */
+    @Deprecated
     public boolean isCached() {
       return cached;
     }
 
     /**
      * Returns how the decision was produced: "fresh" or "cached".
+     *
+     * @deprecated Use {@code getRetryContext().getPriorCompletionStatus()} instead. Will be removed
+     *     in a future major version.
      */
+    @Deprecated
     public String getDecisionSource() {
       return decisionSource;
+    }
+
+    /**
+     * Returns the retry context for this step gate response — the first-class state signal for
+     * {@code (workflow_id, step_id)}. Always populated on responses from platform v7.3.0+. May be
+     * {@code null} on responses from older platforms.
+     *
+     * @return the retry context, or {@code null} if the platform did not return one
+     */
+    public RetryContext getRetryContext() {
+      return retryContext;
     }
 
     public boolean isAllowed() {
@@ -1230,19 +1491,37 @@ public final class WorkflowTypes {
     @JsonProperty("cost_usd")
     private final Double costUsd;
 
+    @JsonProperty("idempotency_key")
+    private final String idempotencyKey;
+
+    /** Pre-5.6 constructor without idempotencyKey (kept for binary compatibility). */
+    public MarkStepCompletedRequest(
+        Map<String, Object> output,
+        Map<String, Object> metadata,
+        Integer tokensIn,
+        Integer tokensOut,
+        Double costUsd) {
+      this(output, metadata, tokensIn, tokensOut, costUsd, null);
+    }
+
     @JsonCreator
     public MarkStepCompletedRequest(
         @JsonProperty("output") Map<String, Object> output,
         @JsonProperty("metadata") Map<String, Object> metadata,
         @JsonProperty("tokens_in") Integer tokensIn,
         @JsonProperty("tokens_out") Integer tokensOut,
-        @JsonProperty("cost_usd") Double costUsd) {
+        @JsonProperty("cost_usd") Double costUsd,
+        @JsonProperty("idempotency_key") String idempotencyKey) {
       this.output = output != null ? Collections.unmodifiableMap(output) : Collections.emptyMap();
       this.metadata =
           metadata != null ? Collections.unmodifiableMap(metadata) : Collections.emptyMap();
       this.tokensIn = tokensIn;
       this.tokensOut = tokensOut;
       this.costUsd = costUsd;
+      if (idempotencyKey != null && idempotencyKey.length() > 255) {
+        throw new IllegalArgumentException("idempotencyKey must be at most 255 characters");
+      }
+      this.idempotencyKey = idempotencyKey;
     }
 
     public Map<String, Object> getOutput() {
@@ -1283,6 +1562,16 @@ public final class WorkflowTypes {
       return costUsd;
     }
 
+    /**
+     * Returns the caller-supplied idempotency key, or {@code null} if none was set.
+     *
+     * <p>Must match the key passed on the corresponding gate call, if any. Mismatch (including
+     * missing-vs-set on either side) yields {@code IdempotencyKeyMismatchException}.
+     */
+    public String getIdempotencyKey() {
+      return idempotencyKey;
+    }
+
     public static Builder builder() {
       return new Builder();
     }
@@ -1293,6 +1582,7 @@ public final class WorkflowTypes {
       private Integer tokensIn;
       private Integer tokensOut;
       private Double costUsd;
+      private String idempotencyKey;
 
       public Builder output(Map<String, Object> output) {
         this.output = output;
@@ -1319,9 +1609,51 @@ public final class WorkflowTypes {
         return this;
       }
 
-      public MarkStepCompletedRequest build() {
-        return new MarkStepCompletedRequest(output, metadata, tokensIn, tokensOut, costUsd);
+      /**
+       * Set the idempotency key (max 255 chars). Must match the key passed on the corresponding
+       * gate call, if any.
+       */
+      public Builder idempotencyKey(String idempotencyKey) {
+        this.idempotencyKey = idempotencyKey;
+        return this;
       }
+
+      public MarkStepCompletedRequest build() {
+        return new MarkStepCompletedRequest(
+            output, metadata, tokensIn, tokensOut, costUsd, idempotencyKey);
+      }
+    }
+  }
+
+  /**
+   * Options for the step gate call that live outside the request body.
+   *
+   * <p>Currently carries {@code includePriorOutput}, sent as {@code ?include_prior_output=true}.
+   */
+  public static final class StepGateOptions {
+    private final boolean includePriorOutput;
+
+    private StepGateOptions(boolean includePriorOutput) {
+      this.includePriorOutput = includePriorOutput;
+    }
+
+    /** Default options: no query params. Equivalent to not passing options at all. */
+    public static StepGateOptions defaults() {
+      return new StepGateOptions(false);
+    }
+
+    /**
+     * Opt in to receiving {@code retry_context.prior_output} populated on the response when a
+     * prior /complete has landed. Default is {@code false} because prior output may be large
+     * and/or contain sensitive data.
+     */
+    public static StepGateOptions includePriorOutput() {
+      return new StepGateOptions(true);
+    }
+
+    /** Returns whether {@code ?include_prior_output=true} should be sent on the gate call. */
+    public boolean isIncludePriorOutput() {
+      return includePriorOutput;
     }
   }
 

--- a/src/main/java/com/getaxonflow/sdk/types/workflow/WorkflowTypes.java
+++ b/src/main/java/com/getaxonflow/sdk/types/workflow/WorkflowTypes.java
@@ -739,7 +739,9 @@ public final class WorkflowTypes {
       this.firstAttemptAt = firstAttemptAt;
       this.lastAttemptAt = lastAttemptAt;
       this.lastDecision = lastDecision;
-      this.idempotencyKey = idempotencyKey;
+      // Contract §3: idempotency_key is always emitted as a string, "" when unset.
+      // Coerce null (older platform responses) to "" for a stable non-null API.
+      this.idempotencyKey = idempotencyKey != null ? idempotencyKey : "";
     }
 
     /** Number of /gate calls for this (workflow, step), including the current call. Always &gt;= 1. */
@@ -794,10 +796,12 @@ public final class WorkflowTypes {
     }
 
     /**
-     * The key the caller set on this step (from the first gate call that supplied one), or
-     * {@code null} if the caller never supplied one. Once set, immutable.
+     * The key the caller set on this step (from the first gate call that supplied one), or the
+     * empty string {@code ""} if the caller never supplied one. Never {@code null} — contract §3
+     * specifies the field is always emitted as a string, and the constructor coerces any legacy
+     * null from older platforms to {@code ""}. Once set on a step, the key is immutable.
      *
-     * @return the idempotency key, or {@code null}
+     * @return the idempotency key (never null; empty string if unset)
      */
     public String getIdempotencyKey() {
       return idempotencyKey;

--- a/src/main/java/com/getaxonflow/sdk/types/workflow/WorkflowTypes.java
+++ b/src/main/java/com/getaxonflow/sdk/types/workflow/WorkflowTypes.java
@@ -739,7 +739,7 @@ public final class WorkflowTypes {
       this.firstAttemptAt = firstAttemptAt;
       this.lastAttemptAt = lastAttemptAt;
       this.lastDecision = lastDecision;
-      this.idempotencyKey = idempotencyKey != null ? idempotencyKey : "";
+      this.idempotencyKey = idempotencyKey;
     }
 
     /** Number of /gate calls for this (workflow, step), including the current call. Always &gt;= 1. */
@@ -794,8 +794,10 @@ public final class WorkflowTypes {
     }
 
     /**
-     * The key the caller set on this step (from the first gate call that supplied one), or the
-     * empty string {@code ""} if the caller never supplied one. Once set, immutable.
+     * The key the caller set on this step (from the first gate call that supplied one), or
+     * {@code null} if the caller never supplied one. Once set, immutable.
+     *
+     * @return the idempotency key, or {@code null}
      */
     public String getIdempotencyKey() {
       return idempotencyKey;

--- a/src/test/java/com/getaxonflow/sdk/RetryContextIdempotencyTest.java
+++ b/src/test/java/com/getaxonflow/sdk/RetryContextIdempotencyTest.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2026 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.sdk;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.getaxonflow.sdk.exceptions.IdempotencyKeyMismatchException;
+import com.getaxonflow.sdk.types.workflow.WorkflowTypes.MarkStepCompletedRequest;
+import com.getaxonflow.sdk.types.workflow.WorkflowTypes.PriorCompletionStatus;
+import com.getaxonflow.sdk.types.workflow.WorkflowTypes.RetryContext;
+import com.getaxonflow.sdk.types.workflow.WorkflowTypes.StepGateOptions;
+import com.getaxonflow.sdk.types.workflow.WorkflowTypes.StepGateRequest;
+import com.getaxonflow.sdk.types.workflow.WorkflowTypes.StepGateResponse;
+import com.getaxonflow.sdk.types.workflow.WorkflowTypes.StepType;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for WCP retry_context + idempotency_key (#1673 Phase 1 + 2). */
+@WireMockTest
+@DisplayName("retry_context + idempotency_key (#1673)")
+class RetryContextIdempotencyTest {
+
+  private static final String GATE_PATH = "/api/v1/workflows/wf_1/steps/step_1/gate";
+  private static final String COMPLETE_PATH = "/api/v1/workflows/wf_1/steps/step_1/complete";
+
+  private AxonFlow axonflow;
+
+  @BeforeEach
+  void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+    axonflow =
+        AxonFlow.create(
+            AxonFlowConfig.builder()
+                .endpoint(wmRuntimeInfo.getHttpBaseUrl())
+                .clientId("test-client")
+                .clientSecret("test-secret")
+                .build());
+  }
+
+  private static String retryContextJson(
+      int gateCount,
+      int completionCount,
+      String priorStatus,
+      boolean priorOutputAvailable,
+      String priorOutput,
+      String priorCompletionAt,
+      String firstAttemptAt,
+      String lastAttemptAt,
+      String lastDecision,
+      String idempotencyKey) {
+    return "{"
+        + "\"gate_count\":" + gateCount + ","
+        + "\"completion_count\":" + completionCount + ","
+        + "\"prior_completion_status\":\"" + priorStatus + "\","
+        + "\"prior_output_available\":" + priorOutputAvailable + ","
+        + "\"prior_output\":" + priorOutput + ","
+        + "\"prior_completion_at\":"
+        + (priorCompletionAt == null ? "null" : "\"" + priorCompletionAt + "\"") + ","
+        + "\"first_attempt_at\":\"" + firstAttemptAt + "\","
+        + "\"last_attempt_at\":\"" + lastAttemptAt + "\","
+        + "\"last_decision\":\"" + lastDecision + "\","
+        + "\"idempotency_key\":\"" + idempotencyKey + "\""
+        + "}";
+  }
+
+  @Test
+  @DisplayName("first-call: gate_count=1, prior_completion_status=none, timestamps equal")
+  void firstCall() {
+    String now = "2026-04-21T15:30:45.123Z";
+    String body =
+        "{"
+            + "\"decision\":\"allow\","
+            + "\"step_id\":\"step_1\","
+            + "\"cached\":false,"
+            + "\"decision_source\":\"fresh\","
+            + "\"retry_context\":"
+            + retryContextJson(1, 0, "none", false, "null", null, now, now, "allow", "")
+            + "}";
+    stubFor(
+        post(urlEqualTo(GATE_PATH))
+            .willReturn(aResponse().withStatus(200).withBody(body).withHeader("Content-Type", "application/json")));
+
+    StepGateResponse gate =
+        axonflow.stepGate("wf_1", "step_1", StepGateRequest.builder().stepType(StepType.LLM_CALL).build());
+
+    RetryContext rc = gate.getRetryContext();
+    assertThat(rc).isNotNull();
+    assertThat(rc.getGateCount()).isEqualTo(1);
+    assertThat(rc.getCompletionCount()).isZero();
+    assertThat(rc.getPriorCompletionStatus()).isEqualTo(PriorCompletionStatus.NONE);
+    assertThat(rc.isPriorOutputAvailable()).isFalse();
+    assertThat(rc.getPriorOutput()).isNull();
+    assertThat(rc.getPriorCompletionAt()).isNull();
+    assertThat(rc.getFirstAttemptAt()).isEqualTo(rc.getLastAttemptAt());
+    assertThat(rc.getLastDecision().getValue()).isEqualTo(gate.getDecision().getValue());
+    assertThat(rc.getIdempotencyKey()).isEmpty();
+    verify(postRequestedFor(urlEqualTo(GATE_PATH)));
+  }
+
+  @Test
+  @DisplayName("second-call after completion: gate_count=2, prior_completion_status=completed")
+  void secondCallAfterCompletion() {
+    String body =
+        "{"
+            + "\"decision\":\"allow\","
+            + "\"step_id\":\"step_1\","
+            + "\"retry_context\":"
+            + retryContextJson(
+                2,
+                1,
+                "completed",
+                true,
+                "null",
+                "2026-04-21T15:30:30.000Z",
+                "2026-04-21T15:30:00.000Z",
+                "2026-04-21T15:31:00.000Z",
+                "allow",
+                "")
+            + "}";
+    stubFor(post(urlEqualTo(GATE_PATH)).willReturn(aResponse().withStatus(200).withBody(body)));
+
+    RetryContext rc =
+        axonflow
+            .stepGate("wf_1", "step_1", StepGateRequest.builder().stepType(StepType.LLM_CALL).build())
+            .getRetryContext();
+    assertThat(rc.getGateCount()).isEqualTo(2);
+    assertThat(rc.getCompletionCount()).isEqualTo(1);
+    assertThat(rc.getPriorCompletionStatus()).isEqualTo(PriorCompletionStatus.COMPLETED);
+    assertThat(rc.isPriorOutputAvailable()).isTrue();
+    assertThat(rc.getPriorCompletionAt()).isNotNull();
+    assertThat(rc.getFirstAttemptAt()).isNotEqualTo(rc.getLastAttemptAt());
+  }
+
+  @Test
+  @DisplayName("second-call without completion: gate_count=2, prior_completion_status=gated_not_completed")
+  void secondCallWithoutCompletion() {
+    String body =
+        "{"
+            + "\"decision\":\"allow\","
+            + "\"step_id\":\"step_1\","
+            + "\"retry_context\":"
+            + retryContextJson(
+                2,
+                0,
+                "gated_not_completed",
+                false,
+                "null",
+                null,
+                "2026-04-21T15:30:00.000Z",
+                "2026-04-21T15:31:00.000Z",
+                "allow",
+                "")
+            + "}";
+    stubFor(post(urlEqualTo(GATE_PATH)).willReturn(aResponse().withStatus(200).withBody(body)));
+
+    RetryContext rc =
+        axonflow
+            .stepGate("wf_1", "step_1", StepGateRequest.builder().stepType(StepType.LLM_CALL).build())
+            .getRetryContext();
+    assertThat(rc.getGateCount()).isEqualTo(2);
+    assertThat(rc.getCompletionCount()).isZero();
+    assertThat(rc.getPriorCompletionStatus()).isEqualTo(PriorCompletionStatus.GATED_NOT_COMPLETED);
+    assertThat(rc.isPriorOutputAvailable()).isFalse();
+    assertThat(rc.getPriorCompletionAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("includePriorOutput() sends ?include_prior_output=true and carries prior_output")
+  void includePriorOutputQueryParam() {
+    String priorOutput = "{\"result\":\"ok\",\"score\":0.92}";
+    String body =
+        "{"
+            + "\"decision\":\"allow\","
+            + "\"step_id\":\"step_1\","
+            + "\"retry_context\":"
+            + retryContextJson(
+                2,
+                1,
+                "completed",
+                true,
+                priorOutput,
+                "2026-04-21T15:30:30.000Z",
+                "2026-04-21T15:30:00.000Z",
+                "2026-04-21T15:31:00.000Z",
+                "allow",
+                "")
+            + "}";
+    stubFor(
+        post(urlEqualTo(GATE_PATH + "?include_prior_output=true"))
+            .willReturn(aResponse().withStatus(200).withBody(body)));
+
+    StepGateResponse gate =
+        axonflow.stepGate(
+            "wf_1",
+            "step_1",
+            StepGateRequest.builder().stepType(StepType.LLM_CALL).build(),
+            StepGateOptions.includePriorOutput());
+
+    verify(postRequestedFor(urlEqualTo(GATE_PATH + "?include_prior_output=true")));
+    Map<String, Object> po = gate.getRetryContext().getPriorOutput();
+    assertThat(po).isNotNull();
+    assertThat(po).containsEntry("result", "ok");
+  }
+
+  @Test
+  @DisplayName("idempotency_key round-trip: gate sets it, retry_context echoes, complete carries")
+  void idempotencyKeyRoundTrip() {
+    String key = "payment:wire:acct4471:invoice-7721";
+    String gateBody =
+        "{"
+            + "\"decision\":\"allow\","
+            + "\"step_id\":\"step_1\","
+            + "\"retry_context\":"
+            + retryContextJson(
+                1,
+                0,
+                "none",
+                false,
+                "null",
+                null,
+                "2026-04-21T15:30:00.000Z",
+                "2026-04-21T15:30:00.000Z",
+                "allow",
+                key)
+            + "}";
+    stubFor(post(urlEqualTo(GATE_PATH)).willReturn(aResponse().withStatus(200).withBody(gateBody)));
+    stubFor(post(urlEqualTo(COMPLETE_PATH)).willReturn(aResponse().withStatus(204)));
+
+    StepGateResponse gate =
+        axonflow.stepGate(
+            "wf_1",
+            "step_1",
+            StepGateRequest.builder().stepType(StepType.LLM_CALL).idempotencyKey(key).build());
+    assertThat(gate.getRetryContext().getIdempotencyKey()).isEqualTo(key);
+
+    axonflow.markStepCompleted(
+        "wf_1",
+        "step_1",
+        MarkStepCompletedRequest.builder().output(Map.of("ok", true)).idempotencyKey(key).build());
+
+    verify(postRequestedFor(urlEqualTo(GATE_PATH)).withRequestBody(containing("\"idempotency_key\":\"" + key + "\"")));
+    verify(postRequestedFor(urlEqualTo(COMPLETE_PATH)).withRequestBody(containing("\"idempotency_key\":\"" + key + "\"")));
+  }
+
+  @Test
+  @DisplayName("markStepCompleted 409 IDEMPOTENCY_KEY_MISMATCH surfaces typed exception")
+  void markStepCompletedIdempotencyMismatch() {
+    String errorBody =
+        "{\"error\":{\"code\":\"IDEMPOTENCY_KEY_MISMATCH\","
+            + "\"message\":\"idempotency_key on complete does not match the key recorded on gate\","
+            + "\"details\":{\"workflow_id\":\"wf_1\",\"step_id\":\"step_1\","
+            + "\"expected_idempotency_key\":\"a\",\"received_idempotency_key\":\"b\"}}}";
+    stubFor(
+        post(urlEqualTo(COMPLETE_PATH))
+            .willReturn(aResponse().withStatus(409).withBody(errorBody).withHeader("Content-Type", "application/json")));
+
+    assertThatThrownBy(
+            () ->
+                axonflow.markStepCompleted(
+                    "wf_1",
+                    "step_1",
+                    MarkStepCompletedRequest.builder().idempotencyKey("b").build()))
+        .isInstanceOf(IdempotencyKeyMismatchException.class)
+        .satisfies(
+            e -> {
+              IdempotencyKeyMismatchException idem = (IdempotencyKeyMismatchException) e;
+              assertThat(idem.getWorkflowId()).isEqualTo("wf_1");
+              assertThat(idem.getStepId()).isEqualTo("step_1");
+              assertThat(idem.getExpectedIdempotencyKey()).isEqualTo("a");
+              assertThat(idem.getReceivedIdempotencyKey()).isEqualTo("b");
+              assertThat(idem.getStatusCode()).isEqualTo(409);
+              assertThat(idem.getErrorCode()).isEqualTo("IDEMPOTENCY_KEY_MISMATCH");
+            });
+  }
+
+  @Test
+  @DisplayName("stepGate 409 IDEMPOTENCY_KEY_MISMATCH surfaces typed exception")
+  void stepGateIdempotencyMismatch() {
+    String errorBody =
+        "{\"error\":{\"code\":\"IDEMPOTENCY_KEY_MISMATCH\",\"message\":\"mismatch\","
+            + "\"details\":{\"workflow_id\":\"wf_1\",\"step_id\":\"step_1\","
+            + "\"expected_idempotency_key\":\"a\",\"received_idempotency_key\":\"b\"}}}";
+    stubFor(post(urlEqualTo(GATE_PATH)).willReturn(aResponse().withStatus(409).withBody(errorBody)));
+
+    assertThatThrownBy(
+            () ->
+                axonflow.stepGate(
+                    "wf_1",
+                    "step_1",
+                    StepGateRequest.builder().stepType(StepType.LLM_CALL).idempotencyKey("b").build()))
+        .isInstanceOf(IdempotencyKeyMismatchException.class)
+        .satisfies(
+            e -> {
+              IdempotencyKeyMismatchException idem = (IdempotencyKeyMismatchException) e;
+              assertThat(idem.getExpectedIdempotencyKey()).isEqualTo("a");
+              assertThat(idem.getReceivedIdempotencyKey()).isEqualTo("b");
+            });
+  }
+}

--- a/src/test/java/com/getaxonflow/sdk/RetryContextIdempotencyTest.java
+++ b/src/test/java/com/getaxonflow/sdk/RetryContextIdempotencyTest.java
@@ -291,6 +291,34 @@ class RetryContextIdempotencyTest {
   }
 
   @Test
+  @DisplayName("RetryContext preserves null idempotency_key (contract §3: \"string or null\")")
+  void retryContextAcceptsNullIdempotencyKey() {
+    String body =
+        "{"
+            + "\"decision\":\"allow\","
+            + "\"step_id\":\"step_1\","
+            + "\"retry_context\":{"
+            + "\"gate_count\":1,"
+            + "\"completion_count\":0,"
+            + "\"prior_completion_status\":\"none\","
+            + "\"prior_output_available\":false,"
+            + "\"prior_output\":null,"
+            + "\"prior_completion_at\":null,"
+            + "\"first_attempt_at\":\"2026-04-21T15:30:00.000Z\","
+            + "\"last_attempt_at\":\"2026-04-21T15:30:00.000Z\","
+            + "\"last_decision\":\"allow\","
+            + "\"idempotency_key\":null"
+            + "}}";
+    stubFor(post(urlEqualTo(GATE_PATH)).willReturn(aResponse().withStatus(200).withBody(body)));
+
+    RetryContext rc =
+        axonflow
+            .stepGate("wf_1", "step_1", StepGateRequest.builder().stepType(StepType.LLM_CALL).build())
+            .getRetryContext();
+    assertThat(rc.getIdempotencyKey()).isNull();
+  }
+
+  @Test
   @DisplayName("stepGate 409 IDEMPOTENCY_KEY_MISMATCH surfaces typed exception")
   void stepGateIdempotencyMismatch() {
     String errorBody =

--- a/src/test/java/com/getaxonflow/sdk/RetryContextIdempotencyTest.java
+++ b/src/test/java/com/getaxonflow/sdk/RetryContextIdempotencyTest.java
@@ -291,8 +291,10 @@ class RetryContextIdempotencyTest {
   }
 
   @Test
-  @DisplayName("RetryContext preserves null idempotency_key (contract §3: \"string or null\")")
-  void retryContextAcceptsNullIdempotencyKey() {
+  @DisplayName("RetryContext coerces legacy null idempotency_key to empty string")
+  void retryContextCoercesNullIdempotencyKeyToEmpty() {
+    // Contract §3 says idempotency_key is always emitted as a string (empty when unset).
+    // Older platform versions could send null; SDK coerces to "" for a stable non-null API.
     String body =
         "{"
             + "\"decision\":\"allow\","
@@ -315,7 +317,7 @@ class RetryContextIdempotencyTest {
         axonflow
             .stepGate("wf_1", "step_1", StepGateRequest.builder().stepType(StepType.LLM_CALL).build())
             .getRetryContext();
-    assertThat(rc.getIdempotencyKey()).isNull();
+    assertThat(rc.getIdempotencyKey()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
## Summary

Implements the Java SDK side of the WCP retry_context + idempotency_key wire contract for [axonflow-enterprise#1673](https://github.com/getaxonflow/axonflow-enterprise/issues/1673) (Phase 1 + Phase 2). Contract: [WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md](https://github.com/getaxonflow/axonflow-enterprise/blob/feat/1673-retry-context-and-idempotency-key/technical-docs/WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md).

- `RetryContext` class + `PriorCompletionStatus` enum (on `StepGateResponse.getRetryContext()`).
- `isCached()` / `getDecisionSource()` preserved, marked `@Deprecated`.
- `stepGate(workflowId, stepId, request, StepGateOptions.includePriorOutput())` — new 4-arg overload sends `?include_prior_output=true`.
- `idempotencyKey` on `StepGateRequest` and `MarkStepCompletedRequest` (validated ≤255 chars at construction).
- `IdempotencyKeyMismatchException` in `com.getaxonflow.sdk.exceptions`, thrown from both `stepGate` and `markStepCompleted` on 409 `IDEMPOTENCY_KEY_MISMATCH`.
- Unit tests for all six shapes from §6.8 of the contract.
- `[Unreleased]` CHANGELOG entry. **No version bump** until platform v7.3.0 tag is cut.

## Bug fix included

`markStepCompleted` previously routed all 409 responses through the shared `handleErrorResponse` path, which stamps `errorCode="VERSION_CONFLICT"` on every 409. That conflated step idempotency conflicts with plan version conflicts. The step gate/complete call sites now parse the 409 body via `toIdempotencyOrGeneric409` and dispatch to `IdempotencyKeyMismatchException` when `error.code` matches, falling back to a generic `AxonFlowException` otherwise. Plan update paths (`updatePlan`) are untouched.

## Coordination

- **Do not merge before** [getaxonflow/axonflow-enterprise#1673](https://github.com/getaxonflow/axonflow-enterprise/issues/1673) platform PR merges.
- After platform merges, reconcile against final response shape (§3), run full E2E per `E2E_EXAMPLES_TESTING_WORKFLOW.md` (CLAUDE.md hard rule #6).
- Version bump lands in this PR once platform tag is cut.

## Test plan

- [x] `./mvnw test` — 1191 passed, 0 failed (7 new tests in `RetryContextIdempotencyTest`)
- [ ] E2E against merged platform — deferred until platform PR merges
- [ ] Version bump commit — deferred until platform release tag is cut