### PR TITLE
feat: rich ApproveStepResponse / RejectStepResponse (v5.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.7.0] - 2026-04-22
 
+### Added
+
+- **Rich `ApproveStepResponse` / `RejectStepResponse`** — both classes now carry
+  the same shape as the step-gate response: `decision` resolves to `"allow"` or
+  `"block"`, `retryContext` mirrors the gate response retry state, `approvedBy`
+  / `approvedAt` / `rejectedBy` / `rejectedAt` carry reviewer identity,
+  `approvalId` is the deterministic HITL queue UUID, `policiesMatched`
+  reconstructs the governance trail. The legacy `workflowId` / `stepId` /
+  `status` fields remain for back-compat.
+- **`planId` on approve/reject responses** — populated when the response comes
+  from the MAP plan-scoped endpoint; empty on WCP plane responses. Same types
+  work across both endpoints.
+- **Back-compat 3-arg constructors** — `new ApproveStepResponse(workflowId, stepId, status)`
+  and `new RejectStepResponse(workflowId, stepId, status)` still compile, so
+  existing test fixtures and SDK consumers keep working without changes.
+
 ### Deprecated
 
 - `DO_NOT_TRACK=1` as an AxonFlow telemetry opt-out — scheduled for removal after 2026-05-05 in the next major release. Use `AXONFLOW_TELEMETRY=off` instead. The SDK emits a one-line migration warning when `DO_NOT_TRACK=1` is the active control and `AXONFLOW_TELEMETRY=off` is not also set.
+
+### Unchanged
+
+- `approveStep(workflowId, stepId)` / `rejectStep(workflowId, stepId, reason)`
+  method signatures on `AxonFlow` are unchanged — only the response fields grew.
 
 ## [5.6.0] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Back-compat 3-arg constructors** — `new ApproveStepResponse(workflowId, stepId, status)`
   and `new RejectStepResponse(workflowId, stepId, status)` still compile, so
   existing test fixtures and SDK consumers keep working without changes.
+- **`getPendingPlanApprovals` / `getPendingPlanApprovalsAsync`** — new client
+  methods that list MAP-plane pending approvals
+  (`GET /api/v1/plans/approvals/pending`), the counterpart of
+  `getPendingApprovals` for the WCP plane. The two-arg form accepts an
+  optional `planId` filter so reviewer tools can scope the listing to one
+  plan. Available on Evaluation+ licenses (same tier gate as the MAP step
+  approve/reject endpoints).
+- **`PendingApproval.planId`** — populated on MAP-plane entries, null on
+  WCP-plane entries. Mirrors the approve/reject asymmetry. `PendingApproval`
+  also gains `stepIndex`, `decision`, `decisionReason`, and `approvalStatus`
+  so reviewer tools can render the full approval context without a second
+  request. The existing 6-arg back-compat constructor still works; new
+  fields default to null / 0 for callers that don't pass them.
+
+### Fixed
+
+- **`approveStep` / `rejectStep` / `getPendingApprovals` endpoint URLs** —
+  all three previously targeted non-existent paths under
+  `/api/v1/workflow-control/` and would fail against a real AxonFlow server.
+  Corrected to the canonical `/api/v1/workflows/{id}/steps/{step_id}/(approve|reject)`
+  and `/api/v1/workflows/approvals/pending` routes. Customers using these
+  methods against a live deployment were receiving 404s; this release makes
+  them work.
+- **`PendingApprovalsResponse` getters and JSON field names aligned with the
+  wire shape** — the class previously declared `getApprovals()` / `getTotal()`
+  over a JSON body with keys `approvals` / `total`, which never matched the
+  server (`pending_approvals` / `count`). Getters renamed to
+  `getPendingApprovals()` / `getCount()` with the correct JSON bindings.
+  Callers that read `response.getApprovals()` or `response.getTotal()` need
+  to update to the new getter names.
 
 ### Deprecated
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.getaxonflow</groupId>
     <artifactId>axonflow-sdk</artifactId>
-    <version>5.6.0</version>
+    <version>5.7.0</version>
     <packaging>jar</packaging>
 
     <name>AxonFlow Java SDK</name>

--- a/src/main/java/com/getaxonflow/sdk/AxonFlow.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlow.java
@@ -5449,7 +5449,8 @@ public final class AxonFlow implements Closeable {
    * Approves a workflow step that requires human approval.
    *
    * <p>Call this when a step gate returns {@code require_approval} to approve the step and allow
-   * the workflow to proceed.
+   * the workflow to proceed. Prefer the two-arg overload when you can pass a comment — the
+   * server requires a comment (min 10 chars) as an audit justification.
    *
    * @param workflowId workflow ID
    * @param stepId step ID
@@ -5458,16 +5459,37 @@ public final class AxonFlow implements Closeable {
    */
   public com.getaxonflow.sdk.types.workflow.WorkflowTypes.ApproveStepResponse approveStep(
       String workflowId, String stepId) {
+    return approveStep(workflowId, stepId, null);
+  }
+
+  /**
+   * Approves a workflow step that requires human approval, with an audit comment.
+   *
+   * <p>The server requires {@code comment} with a minimum of 10 characters — it's the
+   * audit-trail justification that every approval carries into the workflow history.
+   *
+   * @param workflowId workflow ID
+   * @param stepId step ID
+   * @param comment audit justification for the approval (min 10 chars server-side)
+   * @return the approval response
+   * @throws AxonFlowException if the approval fails
+   */
+  public com.getaxonflow.sdk.types.workflow.WorkflowTypes.ApproveStepResponse approveStep(
+      String workflowId, String stepId, String comment) {
     Objects.requireNonNull(workflowId, "workflowId cannot be null");
     Objects.requireNonNull(stepId, "stepId cannot be null");
 
     return retryExecutor.execute(
         () -> {
+          Map<String, Object> body = new HashMap<>();
+          if (comment != null && !comment.isEmpty()) {
+            body.put("comment", comment);
+          }
           Request httpRequest =
               buildOrchestratorRequest(
                   "POST",
                   "/api/v1/workflows/" + workflowId + "/steps/" + stepId + "/approve",
-                  Collections.emptyMap());
+                  body);
           try (Response response = httpClient.newCall(httpRequest).execute()) {
             return parseResponse(
                 response,
@@ -5487,7 +5509,21 @@ public final class AxonFlow implements Closeable {
    */
   public CompletableFuture<com.getaxonflow.sdk.types.workflow.WorkflowTypes.ApproveStepResponse>
       approveStepAsync(String workflowId, String stepId) {
-    return CompletableFuture.supplyAsync(() -> approveStep(workflowId, stepId), asyncExecutor);
+    return approveStepAsync(workflowId, stepId, null);
+  }
+
+  /**
+   * Asynchronously approves a workflow step with an audit comment.
+   *
+   * @param workflowId workflow ID
+   * @param stepId step ID
+   * @param comment audit justification
+   * @return a future containing the approval response
+   */
+  public CompletableFuture<com.getaxonflow.sdk.types.workflow.WorkflowTypes.ApproveStepResponse>
+      approveStepAsync(String workflowId, String stepId, String comment) {
+    return CompletableFuture.supplyAsync(
+        () -> approveStep(workflowId, stepId, comment), asyncExecutor);
   }
 
   /**

--- a/src/main/java/com/getaxonflow/sdk/AxonFlow.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlow.java
@@ -5623,7 +5623,11 @@ public final class AxonFlow implements Closeable {
             hasQuery = true;
           }
           if (planId != null && !planId.isEmpty()) {
-            path.append(hasQuery ? '&' : '?').append("plan_id=").append(planId);
+            path.append(hasQuery ? '&' : '?')
+                .append("plan_id=")
+                .append(
+                    java.net.URLEncoder.encode(
+                        planId, java.nio.charset.StandardCharsets.UTF_8));
           }
 
           Request httpRequest = buildOrchestratorRequest("GET", path.toString(), null);

--- a/src/main/java/com/getaxonflow/sdk/AxonFlow.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlow.java
@@ -5466,7 +5466,7 @@ public final class AxonFlow implements Closeable {
           Request httpRequest =
               buildOrchestratorRequest(
                   "POST",
-                  "/api/v1/workflow-control/" + workflowId + "/steps/" + stepId + "/approve",
+                  "/api/v1/workflows/" + workflowId + "/steps/" + stepId + "/approve",
                   Collections.emptyMap());
           try (Response response = httpClient.newCall(httpRequest).execute()) {
             return parseResponse(
@@ -5532,7 +5532,7 @@ public final class AxonFlow implements Closeable {
           Request httpRequest =
               buildOrchestratorRequest(
                   "POST",
-                  "/api/v1/workflow-control/" + workflowId + "/steps/" + stepId + "/reject",
+                  "/api/v1/workflows/" + workflowId + "/steps/" + stepId + "/reject",
                   body);
           try (Response response = httpClient.newCall(httpRequest).execute()) {
             return parseResponse(
@@ -5581,7 +5581,7 @@ public final class AxonFlow implements Closeable {
       getPendingApprovals(int limit) {
     return retryExecutor.execute(
         () -> {
-          StringBuilder path = new StringBuilder("/api/v1/workflow-control/pending-approvals");
+          StringBuilder path = new StringBuilder("/api/v1/workflows/approvals/pending");
           if (limit > 0) {
             path.append("?limit=").append(limit);
           }
@@ -5596,6 +5596,83 @@ public final class AxonFlow implements Closeable {
           }
         },
         "getPendingApprovals");
+  }
+
+  /**
+   * Gets MAP-plane pending approvals — the counterpart of {@link #getPendingApprovals(int)}.
+   *
+   * <p>Lists pending approvals for MAP-backed workflows ({@code GET /api/v1/plans/approvals/pending}).
+   * Every returned entry has {@code planId} populated; WCP-only approvals are not returned.
+   *
+   * <p>Requires an Evaluation or Enterprise license (same tier gate as the MAP step approve/reject
+   * endpoints).
+   *
+   * @param limit maximum number of pending approvals to return (0 for server default)
+   * @param planId optional plan id filter — when non-null, scopes the listing to a single plan
+   * @return the pending approvals response
+   * @throws AxonFlowException if the request fails
+   */
+  public com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApprovalsResponse
+      getPendingPlanApprovals(int limit, String planId) {
+    return retryExecutor.execute(
+        () -> {
+          StringBuilder path = new StringBuilder("/api/v1/plans/approvals/pending");
+          boolean hasQuery = false;
+          if (limit > 0) {
+            path.append("?limit=").append(limit);
+            hasQuery = true;
+          }
+          if (planId != null && !planId.isEmpty()) {
+            path.append(hasQuery ? '&' : '?').append("plan_id=").append(planId);
+          }
+
+          Request httpRequest = buildOrchestratorRequest("GET", path.toString(), null);
+          try (Response response = httpClient.newCall(httpRequest).execute()) {
+            return parseResponse(
+                response,
+                new TypeReference<
+                    com.getaxonflow.sdk.types.workflow.WorkflowTypes
+                        .PendingApprovalsResponse>() {});
+          }
+        },
+        "getPendingPlanApprovals");
+  }
+
+  /**
+   * Gets all MAP-plane pending approvals with the server default limit and no plan filter.
+   *
+   * @return the pending approvals response
+   * @throws AxonFlowException if the request fails
+   */
+  public com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApprovalsResponse
+      getPendingPlanApprovals() {
+    return getPendingPlanApprovals(0, null);
+  }
+
+  /**
+   * Gets MAP-plane pending approvals with a limit and no plan filter.
+   *
+   * @param limit maximum number of pending approvals to return
+   * @return the pending approvals response
+   * @throws AxonFlowException if the request fails
+   */
+  public com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApprovalsResponse
+      getPendingPlanApprovals(int limit) {
+    return getPendingPlanApprovals(limit, null);
+  }
+
+  /**
+   * Asynchronously gets MAP-plane pending approvals.
+   *
+   * @param limit maximum number of pending approvals to return
+   * @param planId optional plan id filter
+   * @return a future containing the pending approvals response
+   */
+  public CompletableFuture<
+          com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApprovalsResponse>
+      getPendingPlanApprovalsAsync(int limit, String planId) {
+    return CompletableFuture.supplyAsync(
+        () -> getPendingPlanApprovals(limit, planId), asyncExecutor);
   }
 
   /**

--- a/src/main/java/com/getaxonflow/sdk/types/workflow/WorkflowTypes.java
+++ b/src/main/java/com/getaxonflow/sdk/types/workflow/WorkflowTypes.java
@@ -2104,7 +2104,15 @@ public final class WorkflowTypes {
     }
   }
 
-  /** A pending approval for a workflow step. */
+  /**
+   * A pending approval for a workflow step.
+   *
+   * <p>Populated by both {@code getPendingApprovals} (WCP plane) and
+   * {@code getPendingPlanApprovals} (MAP plane). The {@code planId} field is
+   * the one intentional asymmetry between the two planes — populated on
+   * MAP-plane entries, {@code null} on WCP-plane entries (mirrors ADR-046
+   * parity rule).
+   */
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static final class PendingApproval {
 
@@ -2114,8 +2122,14 @@ public final class WorkflowTypes {
     @JsonProperty("workflow_name")
     private final String workflowName;
 
+    @JsonProperty("plan_id")
+    private final String planId;
+
     @JsonProperty("step_id")
     private final String stepId;
+
+    @JsonProperty("step_index")
+    private final int stepIndex;
 
     @JsonProperty("step_name")
     private final String stepName;
@@ -2123,22 +2137,55 @@ public final class WorkflowTypes {
     @JsonProperty("step_type")
     private final String stepType;
 
+    @JsonProperty("decision")
+    private final String decision;
+
+    @JsonProperty("decision_reason")
+    private final String decisionReason;
+
+    @JsonProperty("approval_status")
+    private final String approvalStatus;
+
     @JsonProperty("created_at")
     private final String createdAt;
+
+    /**
+     * Back-compat constructor — callers passing the pre-v7.4.0 field set still compile. plan_id,
+     * step_index, decision, decision_reason, and approval_status default to null / 0.
+     */
+    public PendingApproval(
+        String workflowId,
+        String workflowName,
+        String stepId,
+        String stepName,
+        String stepType,
+        String createdAt) {
+      this(workflowId, workflowName, null, stepId, 0, stepName, stepType, null, null, null, createdAt);
+    }
 
     @JsonCreator
     public PendingApproval(
         @JsonProperty("workflow_id") String workflowId,
         @JsonProperty("workflow_name") String workflowName,
+        @JsonProperty("plan_id") String planId,
         @JsonProperty("step_id") String stepId,
+        @JsonProperty("step_index") int stepIndex,
         @JsonProperty("step_name") String stepName,
         @JsonProperty("step_type") String stepType,
+        @JsonProperty("decision") String decision,
+        @JsonProperty("decision_reason") String decisionReason,
+        @JsonProperty("approval_status") String approvalStatus,
         @JsonProperty("created_at") String createdAt) {
       this.workflowId = workflowId;
       this.workflowName = workflowName;
+      this.planId = planId;
       this.stepId = stepId;
+      this.stepIndex = stepIndex;
       this.stepName = stepName;
       this.stepType = stepType;
+      this.decision = decision;
+      this.decisionReason = decisionReason;
+      this.approvalStatus = approvalStatus;
       this.createdAt = createdAt;
     }
 
@@ -2150,8 +2197,21 @@ public final class WorkflowTypes {
       return workflowName;
     }
 
+    /**
+     * MAP plan id — populated on MAP-plane entries, null on WCP-plane entries.
+     *
+     * @return the plan id, or null for WCP-plane entries
+     */
+    public String getPlanId() {
+      return planId;
+    }
+
     public String getStepId() {
       return stepId;
+    }
+
+    public int getStepIndex() {
+      return stepIndex;
     }
 
     public String getStepName() {
@@ -2160,6 +2220,18 @@ public final class WorkflowTypes {
 
     public String getStepType() {
       return stepType;
+    }
+
+    public String getDecision() {
+      return decision;
+    }
+
+    public String getDecisionReason() {
+      return decisionReason;
+    }
+
+    public String getApprovalStatus() {
+      return approvalStatus;
     }
 
     public String getCreatedAt() {
@@ -2171,17 +2243,33 @@ public final class WorkflowTypes {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       PendingApproval that = (PendingApproval) o;
-      return Objects.equals(workflowId, that.workflowId)
+      return stepIndex == that.stepIndex
+          && Objects.equals(workflowId, that.workflowId)
           && Objects.equals(workflowName, that.workflowName)
+          && Objects.equals(planId, that.planId)
           && Objects.equals(stepId, that.stepId)
           && Objects.equals(stepName, that.stepName)
           && Objects.equals(stepType, that.stepType)
+          && Objects.equals(decision, that.decision)
+          && Objects.equals(decisionReason, that.decisionReason)
+          && Objects.equals(approvalStatus, that.approvalStatus)
           && Objects.equals(createdAt, that.createdAt);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(workflowId, workflowName, stepId, stepName, stepType, createdAt);
+      return Objects.hash(
+          workflowId,
+          workflowName,
+          planId,
+          stepId,
+          stepIndex,
+          stepName,
+          stepType,
+          decision,
+          decisionReason,
+          approvalStatus,
+          createdAt);
     }
 
     @Override
@@ -2193,14 +2281,25 @@ public final class WorkflowTypes {
           + ", workflowName='"
           + workflowName
           + '\''
+          + ", planId='"
+          + planId
+          + '\''
           + ", stepId='"
           + stepId
           + '\''
+          + ", stepIndex="
+          + stepIndex
           + ", stepName='"
           + stepName
           + '\''
           + ", stepType='"
           + stepType
+          + '\''
+          + ", decision='"
+          + decision
+          + '\''
+          + ", approvalStatus='"
+          + approvalStatus
           + '\''
           + ", createdAt='"
           + createdAt
@@ -2209,31 +2308,36 @@ public final class WorkflowTypes {
     }
   }
 
-  /** Response containing a list of pending approvals. */
+  /**
+   * Response containing a list of pending approvals. Shape matches the server wire contract:
+   * {@code pending_approvals} array plus {@code count}.
+   */
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static final class PendingApprovalsResponse {
 
-    @JsonProperty("approvals")
-    private final List<PendingApproval> approvals;
+    @JsonProperty("pending_approvals")
+    private final List<PendingApproval> pendingApprovals;
 
-    @JsonProperty("total")
-    private final int total;
+    @JsonProperty("count")
+    private final int count;
 
     @JsonCreator
     public PendingApprovalsResponse(
-        @JsonProperty("approvals") List<PendingApproval> approvals,
-        @JsonProperty("total") int total) {
-      this.approvals =
-          approvals != null ? Collections.unmodifiableList(approvals) : Collections.emptyList();
-      this.total = total;
+        @JsonProperty("pending_approvals") List<PendingApproval> pendingApprovals,
+        @JsonProperty("count") int count) {
+      this.pendingApprovals =
+          pendingApprovals != null
+              ? Collections.unmodifiableList(pendingApprovals)
+              : Collections.emptyList();
+      this.count = count;
     }
 
-    public List<PendingApproval> getApprovals() {
-      return approvals;
+    public List<PendingApproval> getPendingApprovals() {
+      return pendingApprovals;
     }
 
-    public int getTotal() {
-      return total;
+    public int getCount() {
+      return count;
     }
 
     @Override
@@ -2241,17 +2345,22 @@ public final class WorkflowTypes {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       PendingApprovalsResponse that = (PendingApprovalsResponse) o;
-      return total == that.total && Objects.equals(approvals, that.approvals);
+      return count == that.count && Objects.equals(pendingApprovals, that.pendingApprovals);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(approvals, total);
+      return Objects.hash(pendingApprovals, count);
     }
 
     @Override
     public String toString() {
-      return "PendingApprovalsResponse{" + "approvals=" + approvals + ", total=" + total + '}';
+      return "PendingApprovalsResponse{"
+          + "pendingApprovals="
+          + pendingApprovals
+          + ", count="
+          + count
+          + '}';
     }
   }
 }

--- a/src/main/java/com/getaxonflow/sdk/types/workflow/WorkflowTypes.java
+++ b/src/main/java/com/getaxonflow/sdk/types/workflow/WorkflowTypes.java
@@ -1688,12 +1688,27 @@ public final class WorkflowTypes {
   // WCP Approval Types
   // ========================================================================
 
-  /** Response from approving a workflow step. */
+  /**
+   * Response from approving a workflow step.
+   *
+   * <p>Starting with v5.7.0 the server returns the rich step-gate shape on approve: {@code
+   * decision} resolves to {@code "allow"} once approved, {@code retryContext} mirrors the gate
+   * response retry state, {@code approvedBy} / {@code approvedAt} carry the reviewer identity,
+   * {@code approvalId} is the deterministic HITL queue entry UUID, and {@code policiesMatched}
+   * reconstructs the governance trail. Legacy fields ({@code workflowId}, {@code stepId}, {@code
+   * status}) remain for back-compat.
+   *
+   * <p>See ADR-046 (HITL response parity) — the same shape is returned by the WCP endpoint and the
+   * MAP plan-scoped equivalent, which is why the new {@code planId} field exists.
+   */
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static final class ApproveStepResponse {
 
     @JsonProperty("workflow_id")
     private final String workflowId;
+
+    @JsonProperty("plan_id")
+    private final String planId;
 
     @JsonProperty("step_id")
     private final String stepId;
@@ -1701,26 +1716,133 @@ public final class WorkflowTypes {
     @JsonProperty("status")
     private final String status;
 
+    @JsonProperty("decision")
+    private final String decision;
+
+    @JsonProperty("reason")
+    private final String reason;
+
+    @JsonProperty("approval_status")
+    private final String approvalStatus;
+
+    @JsonProperty("approval_id")
+    private final String approvalId;
+
+    @JsonProperty("approved_by")
+    private final String approvedBy;
+
+    @JsonProperty("approved_at")
+    private final String approvedAt;
+
+    @JsonProperty("policies_matched")
+    private final List<PolicyMatch> policiesMatched;
+
+    @JsonProperty("retry_context")
+    private final RetryContext retryContext;
+
+    @JsonProperty("message")
+    private final String message;
+
     @JsonCreator
     public ApproveStepResponse(
         @JsonProperty("workflow_id") String workflowId,
+        @JsonProperty("plan_id") String planId,
         @JsonProperty("step_id") String stepId,
-        @JsonProperty("status") String status) {
+        @JsonProperty("status") String status,
+        @JsonProperty("decision") String decision,
+        @JsonProperty("reason") String reason,
+        @JsonProperty("approval_status") String approvalStatus,
+        @JsonProperty("approval_id") String approvalId,
+        @JsonProperty("approved_by") String approvedBy,
+        @JsonProperty("approved_at") String approvedAt,
+        @JsonProperty("policies_matched") List<PolicyMatch> policiesMatched,
+        @JsonProperty("retry_context") RetryContext retryContext,
+        @JsonProperty("message") String message) {
       this.workflowId = workflowId;
+      this.planId = planId;
       this.stepId = stepId;
       this.status = status;
+      this.decision = decision;
+      this.reason = reason;
+      this.approvalStatus = approvalStatus;
+      this.approvalId = approvalId;
+      this.approvedBy = approvedBy;
+      this.approvedAt = approvedAt;
+      this.policiesMatched = policiesMatched;
+      this.retryContext = retryContext;
+      this.message = message;
+    }
+
+    /**
+     * Back-compat constructor used by callers that only know the legacy (workflow_id, step_id,
+     * status) shape. Every rich field (decision, retry_context, approval metadata) defaults to
+     * null. Retained so existing test fixtures keep compiling after v5.7.0.
+     */
+    public ApproveStepResponse(String workflowId, String stepId, String status) {
+      this(workflowId, null, stepId, status, null, null, null, null, null, null, null, null, null);
     }
 
     public String getWorkflowId() {
       return workflowId;
     }
 
+    /** MAP plan id — populated on plan-scoped responses, null otherwise. */
+    public String getPlanId() {
+      return planId;
+    }
+
     public String getStepId() {
       return stepId;
     }
 
+    /** Legacy status field — mirrors {@link #getApprovalStatus()}. Retained for back-compat. */
     public String getStatus() {
       return status;
+    }
+
+    /** Post-approval decision: {@code "allow"} on successful approval. */
+    public String getDecision() {
+      return decision;
+    }
+
+    /** Decision reason text (prefixed with {@code "Approved: "} on the approve path). */
+    public String getReason() {
+      return reason;
+    }
+
+    /** Terminal approval status: {@code pending}, {@code approved}, {@code rejected}. */
+    public String getApprovalStatus() {
+      return approvalStatus;
+    }
+
+    /** HITL queue entry UUID (deterministic UUID v5 over {@code (workflow_id, step_id)}). */
+    public String getApprovalId() {
+      return approvalId;
+    }
+
+    /** Identity (X-User-ID) that approved the step. */
+    public String getApprovedBy() {
+      return approvedBy;
+    }
+
+    /** ISO 8601 timestamp when the approval was persisted. */
+    public String getApprovedAt() {
+      return approvedAt;
+    }
+
+    /** Policies that triggered the original {@code require_approval} decision. */
+    public List<PolicyMatch> getPoliciesMatched() {
+      return policiesMatched;
+    }
+
+    /** Retry / idempotency state — mirrors the gate response retry_context. */
+    public RetryContext getRetryContext() {
+      return retryContext;
+    }
+
+    /** Human-readable status summary. */
+    public String getMessage() {
+      return message;
     }
 
     @Override
@@ -1729,13 +1851,36 @@ public final class WorkflowTypes {
       if (o == null || getClass() != o.getClass()) return false;
       ApproveStepResponse that = (ApproveStepResponse) o;
       return Objects.equals(workflowId, that.workflowId)
+          && Objects.equals(planId, that.planId)
           && Objects.equals(stepId, that.stepId)
-          && Objects.equals(status, that.status);
+          && Objects.equals(status, that.status)
+          && Objects.equals(decision, that.decision)
+          && Objects.equals(reason, that.reason)
+          && Objects.equals(approvalStatus, that.approvalStatus)
+          && Objects.equals(approvalId, that.approvalId)
+          && Objects.equals(approvedBy, that.approvedBy)
+          && Objects.equals(approvedAt, that.approvedAt)
+          && Objects.equals(policiesMatched, that.policiesMatched)
+          && Objects.equals(retryContext, that.retryContext)
+          && Objects.equals(message, that.message);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(workflowId, stepId, status);
+      return Objects.hash(
+          workflowId,
+          planId,
+          stepId,
+          status,
+          decision,
+          reason,
+          approvalStatus,
+          approvalId,
+          approvedBy,
+          approvedAt,
+          policiesMatched,
+          retryContext,
+          message);
     }
 
     @Override
@@ -1747,19 +1892,34 @@ public final class WorkflowTypes {
           + ", stepId='"
           + stepId
           + '\''
-          + ", status='"
-          + status
+          + ", decision='"
+          + decision
+          + '\''
+          + ", approvalStatus='"
+          + approvalStatus
+          + '\''
+          + ", approvedBy='"
+          + approvedBy
           + '\''
           + '}';
     }
   }
 
-  /** Response from rejecting a workflow step. */
+  /**
+   * Response from rejecting a workflow step.
+   *
+   * <p>Starting with v5.7.0 the server returns the rich step-gate shape on reject: {@code decision}
+   * resolves to {@code "block"}, {@code rejectedBy} / {@code rejectedAt} carry the reviewer
+   * identity, and {@code retryContext} mirrors the gate response state. See ADR-046.
+   */
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static final class RejectStepResponse {
 
     @JsonProperty("workflow_id")
     private final String workflowId;
+
+    @JsonProperty("plan_id")
+    private final String planId;
 
     @JsonProperty("step_id")
     private final String stepId;
@@ -1767,18 +1927,77 @@ public final class WorkflowTypes {
     @JsonProperty("status")
     private final String status;
 
+    @JsonProperty("decision")
+    private final String decision;
+
+    @JsonProperty("reason")
+    private final String reason;
+
+    @JsonProperty("approval_status")
+    private final String approvalStatus;
+
+    @JsonProperty("approval_id")
+    private final String approvalId;
+
+    @JsonProperty("rejected_by")
+    private final String rejectedBy;
+
+    @JsonProperty("rejected_at")
+    private final String rejectedAt;
+
+    @JsonProperty("policies_matched")
+    private final List<PolicyMatch> policiesMatched;
+
+    @JsonProperty("retry_context")
+    private final RetryContext retryContext;
+
+    @JsonProperty("message")
+    private final String message;
+
     @JsonCreator
     public RejectStepResponse(
         @JsonProperty("workflow_id") String workflowId,
+        @JsonProperty("plan_id") String planId,
         @JsonProperty("step_id") String stepId,
-        @JsonProperty("status") String status) {
+        @JsonProperty("status") String status,
+        @JsonProperty("decision") String decision,
+        @JsonProperty("reason") String reason,
+        @JsonProperty("approval_status") String approvalStatus,
+        @JsonProperty("approval_id") String approvalId,
+        @JsonProperty("rejected_by") String rejectedBy,
+        @JsonProperty("rejected_at") String rejectedAt,
+        @JsonProperty("policies_matched") List<PolicyMatch> policiesMatched,
+        @JsonProperty("retry_context") RetryContext retryContext,
+        @JsonProperty("message") String message) {
       this.workflowId = workflowId;
+      this.planId = planId;
       this.stepId = stepId;
       this.status = status;
+      this.decision = decision;
+      this.reason = reason;
+      this.approvalStatus = approvalStatus;
+      this.approvalId = approvalId;
+      this.rejectedBy = rejectedBy;
+      this.rejectedAt = rejectedAt;
+      this.policiesMatched = policiesMatched;
+      this.retryContext = retryContext;
+      this.message = message;
+    }
+
+    /**
+     * Back-compat constructor matching the legacy (workflow_id, step_id, status) shape.
+     * Rich fields default to null. Retained so existing test fixtures keep compiling.
+     */
+    public RejectStepResponse(String workflowId, String stepId, String status) {
+      this(workflowId, null, stepId, status, null, null, null, null, null, null, null, null, null);
     }
 
     public String getWorkflowId() {
       return workflowId;
+    }
+
+    public String getPlanId() {
+      return planId;
     }
 
     public String getStepId() {
@@ -1789,19 +2008,78 @@ public final class WorkflowTypes {
       return status;
     }
 
+    public String getDecision() {
+      return decision;
+    }
+
+    public String getReason() {
+      return reason;
+    }
+
+    public String getApprovalStatus() {
+      return approvalStatus;
+    }
+
+    public String getApprovalId() {
+      return approvalId;
+    }
+
+    public String getRejectedBy() {
+      return rejectedBy;
+    }
+
+    public String getRejectedAt() {
+      return rejectedAt;
+    }
+
+    public List<PolicyMatch> getPoliciesMatched() {
+      return policiesMatched;
+    }
+
+    public RetryContext getRetryContext() {
+      return retryContext;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       RejectStepResponse that = (RejectStepResponse) o;
       return Objects.equals(workflowId, that.workflowId)
+          && Objects.equals(planId, that.planId)
           && Objects.equals(stepId, that.stepId)
-          && Objects.equals(status, that.status);
+          && Objects.equals(status, that.status)
+          && Objects.equals(decision, that.decision)
+          && Objects.equals(reason, that.reason)
+          && Objects.equals(approvalStatus, that.approvalStatus)
+          && Objects.equals(approvalId, that.approvalId)
+          && Objects.equals(rejectedBy, that.rejectedBy)
+          && Objects.equals(rejectedAt, that.rejectedAt)
+          && Objects.equals(policiesMatched, that.policiesMatched)
+          && Objects.equals(retryContext, that.retryContext)
+          && Objects.equals(message, that.message);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(workflowId, stepId, status);
+      return Objects.hash(
+          workflowId,
+          planId,
+          stepId,
+          status,
+          decision,
+          reason,
+          approvalStatus,
+          approvalId,
+          rejectedBy,
+          rejectedAt,
+          policiesMatched,
+          retryContext,
+          message);
     }
 
     @Override
@@ -1813,8 +2091,14 @@ public final class WorkflowTypes {
           + ", stepId='"
           + stepId
           + '\''
-          + ", status='"
-          + status
+          + ", decision='"
+          + decision
+          + '\''
+          + ", approvalStatus='"
+          + approvalStatus
+          + '\''
+          + ", rejectedBy='"
+          + rejectedBy
           + '\''
           + '}';
     }

--- a/src/test/java/com/getaxonflow/sdk/AxonFlowTest.java
+++ b/src/test/java/com/getaxonflow/sdk/AxonFlowTest.java
@@ -2212,7 +2212,7 @@ class AxonFlowTest {
   @DisplayName("approveStep should return approval response")
   void approveStepShouldReturnResponse() {
     stubFor(
-        post(urlEqualTo("/api/v1/workflow-control/wf-123/steps/step-1/approve"))
+        post(urlEqualTo("/api/v1/workflows/wf-123/steps/step-1/approve"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -2232,7 +2232,7 @@ class AxonFlowTest {
   @DisplayName("approveStepAsync should return future")
   void approveStepAsyncShouldReturnFuture() throws Exception {
     stubFor(
-        post(urlEqualTo("/api/v1/workflow-control/wf-456/steps/step-2/approve"))
+        post(urlEqualTo("/api/v1/workflows/wf-456/steps/step-2/approve"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -2266,7 +2266,7 @@ class AxonFlowTest {
   @DisplayName("rejectStep should return rejection response")
   void rejectStepShouldReturnResponse() {
     stubFor(
-        post(urlEqualTo("/api/v1/workflow-control/wf-123/steps/step-1/reject"))
+        post(urlEqualTo("/api/v1/workflows/wf-123/steps/step-1/reject"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -2286,7 +2286,7 @@ class AxonFlowTest {
   @DisplayName("rejectStepAsync should return future")
   void rejectStepAsyncShouldReturnFuture() throws Exception {
     stubFor(
-        post(urlEqualTo("/api/v1/workflow-control/wf-789/steps/step-3/reject"))
+        post(urlEqualTo("/api/v1/workflows/wf-789/steps/step-3/reject"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -2306,60 +2306,174 @@ class AxonFlowTest {
   @DisplayName("getPendingApprovals should return pending approvals")
   void getPendingApprovalsShouldReturnApprovals() {
     stubFor(
-        get(urlEqualTo("/api/v1/workflow-control/pending-approvals"))
+        get(urlEqualTo("/api/v1/workflows/approvals/pending"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
                     .withHeader("Content-Type", "application/json")
                     .withBody(
-                        "{\"approvals\":[{\"workflow_id\":\"wf-1\",\"workflow_name\":\"Review\","
-                            + "\"step_id\":\"s-1\",\"step_name\":\"Generate\","
-                            + "\"step_type\":\"llm_call\",\"created_at\":\"2026-02-07T10:00:00Z\"}],\"total\":1}")));
+                        "{\"pending_approvals\":[{\"workflow_id\":\"wf-1\",\"workflow_name\":\"Review\","
+                            + "\"step_id\":\"s-1\",\"step_index\":0,\"step_name\":\"Generate\","
+                            + "\"step_type\":\"llm_call\",\"decision\":\"require_approval\","
+                            + "\"created_at\":\"2026-02-07T10:00:00Z\"}],\"count\":1}")));
 
     com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApprovalsResponse response =
         axonflow.getPendingApprovals();
 
-    assertThat(response.getTotal()).isEqualTo(1);
-    assertThat(response.getApprovals()).hasSize(1);
-    assertThat(response.getApprovals().get(0).getWorkflowId()).isEqualTo("wf-1");
-    assertThat(response.getApprovals().get(0).getStepName()).isEqualTo("Generate");
+    assertThat(response.getCount()).isEqualTo(1);
+    assertThat(response.getPendingApprovals()).hasSize(1);
+    assertThat(response.getPendingApprovals().get(0).getWorkflowId()).isEqualTo("wf-1");
+    assertThat(response.getPendingApprovals().get(0).getStepName()).isEqualTo("Generate");
+    // WCP entries must NOT carry plan_id
+    assertThat(response.getPendingApprovals().get(0).getPlanId()).isNull();
   }
 
   @Test
   @DisplayName("getPendingApprovals with limit should add query parameter")
   void getPendingApprovalsWithLimitShouldAddQueryParam() {
     stubFor(
-        get(urlEqualTo("/api/v1/workflow-control/pending-approvals?limit=10"))
+        get(urlEqualTo("/api/v1/workflows/approvals/pending?limit=10"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
                     .withHeader("Content-Type", "application/json")
-                    .withBody("{\"approvals\":[],\"total\":0}")));
+                    .withBody("{\"pending_approvals\":[],\"count\":0}")));
 
     com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApprovalsResponse response =
         axonflow.getPendingApprovals(10);
 
-    assertThat(response.getTotal()).isEqualTo(0);
-    assertThat(response.getApprovals()).isEmpty();
+    assertThat(response.getCount()).isEqualTo(0);
+    assertThat(response.getPendingApprovals()).isEmpty();
   }
 
   @Test
   @DisplayName("getPendingApprovalsAsync should return future")
   void getPendingApprovalsAsyncShouldReturnFuture() throws Exception {
     stubFor(
-        get(urlEqualTo("/api/v1/workflow-control/pending-approvals?limit=5"))
+        get(urlEqualTo("/api/v1/workflows/approvals/pending?limit=5"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
                     .withHeader("Content-Type", "application/json")
-                    .withBody("{\"approvals\":[],\"total\":0}")));
+                    .withBody("{\"pending_approvals\":[],\"count\":0}")));
 
     CompletableFuture<com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApprovalsResponse>
         future = axonflow.getPendingApprovalsAsync(5);
     com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApprovalsResponse response =
         future.get();
 
-    assertThat(response.getTotal()).isEqualTo(0);
+    assertThat(response.getCount()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("getPendingPlanApprovals should return MAP-plane approvals with plan_id")
+  void getPendingPlanApprovalsShouldReturnMapApprovals() {
+    stubFor(
+        get(urlEqualTo("/api/v1/plans/approvals/pending"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        "{\"pending_approvals\":[{\"workflow_id\":\"wf_map_abc\","
+                            + "\"workflow_name\":\"map-confirm-plan-abc\","
+                            + "\"plan_id\":\"plan-abc\","
+                            + "\"step_id\":\"step_0_analyze\",\"step_index\":0,"
+                            + "\"step_name\":\"Analyze transaction\",\"step_type\":\"tool_call\","
+                            + "\"decision\":\"require_approval\","
+                            + "\"created_at\":\"2026-04-22T10:00:00Z\"}],\"count\":1}")));
+
+    com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApprovalsResponse response =
+        axonflow.getPendingPlanApprovals();
+
+    assertThat(response.getCount()).isEqualTo(1);
+    assertThat(response.getPendingApprovals()).hasSize(1);
+    assertThat(response.getPendingApprovals().get(0).getPlanId()).isEqualTo("plan-abc");
+    assertThat(response.getPendingApprovals().get(0).getStepName()).isEqualTo("Analyze transaction");
+  }
+
+  @Test
+  @DisplayName("getPendingPlanApprovals with plan_id filter should propagate to query string")
+  void getPendingPlanApprovalsWithPlanIdFilterShouldEncodeQuery() {
+    stubFor(
+        get(urlEqualTo("/api/v1/plans/approvals/pending?plan_id=plan-abc"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"pending_approvals\":[],\"count\":0}")));
+
+    com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApprovalsResponse response =
+        axonflow.getPendingPlanApprovals(0, "plan-abc");
+
+    assertThat(response.getCount()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("getPendingPlanApprovals with limit and plan_id should encode both")
+  void getPendingPlanApprovalsWithLimitAndPlanIdShouldEncodeBoth() {
+    stubFor(
+        get(urlEqualTo("/api/v1/plans/approvals/pending?limit=3&plan_id=plan-x"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"pending_approvals\":[],\"count\":0}")));
+
+    com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApprovalsResponse response =
+        axonflow.getPendingPlanApprovals(3, "plan-x");
+
+    assertThat(response.getCount()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("getPendingPlanApprovals with limit only omits plan_id")
+  void getPendingPlanApprovalsWithLimitOnlyOmitsPlanId() {
+    stubFor(
+        get(urlEqualTo("/api/v1/plans/approvals/pending?limit=5"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"pending_approvals\":[],\"count\":0}")));
+
+    com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApprovalsResponse response =
+        axonflow.getPendingPlanApprovals(5);
+
+    assertThat(response.getCount()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("getPendingPlanApprovalsAsync should return future")
+  void getPendingPlanApprovalsAsyncShouldReturnFuture() throws Exception {
+    stubFor(
+        get(urlEqualTo("/api/v1/plans/approvals/pending"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"pending_approvals\":[],\"count\":0}")));
+
+    CompletableFuture<com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApprovalsResponse>
+        future = axonflow.getPendingPlanApprovalsAsync(0, null);
+    com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApprovalsResponse response =
+        future.get();
+
+    assertThat(response.getCount()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("PendingApproval back-compat constructor preserves legacy field set")
+  void pendingApprovalBackCompatConstructor() {
+    com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApproval approval =
+        new com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApproval(
+            "wf-1", "Review", "s-1", "Generate", "llm_call", "2026-02-07T10:00:00Z");
+    assertThat(approval.getWorkflowId()).isEqualTo("wf-1");
+    assertThat(approval.getStepName()).isEqualTo("Generate");
+    // New fields default to null / 0 for the legacy constructor
+    assertThat(approval.getPlanId()).isNull();
+    assertThat(approval.getStepIndex()).isEqualTo(0);
+    assertThat(approval.getDecision()).isNull();
   }
 
   // ========================================================================

--- a/src/test/java/com/getaxonflow/sdk/AxonFlowTest.java
+++ b/src/test/java/com/getaxonflow/sdk/AxonFlowTest.java
@@ -2444,6 +2444,26 @@ class AxonFlowTest {
   }
 
   @Test
+  @DisplayName("getPendingPlanApprovals URL-encodes plan_id with special characters")
+  void getPendingPlanApprovalsUrlEncodesPlanId() {
+    // A plan_id containing characters that would break a raw concatenation
+    // must be URL-encoded on the wire. URLEncoder encodes ' ' -> '+' and
+    // '&' -> '%26'; the stub asserts the encoded form lands on the server.
+    stubFor(
+        get(urlEqualTo("/api/v1/plans/approvals/pending?plan_id=plan+a%26b"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"pending_approvals\":[],\"count\":0}")));
+
+    com.getaxonflow.sdk.types.workflow.WorkflowTypes.PendingApprovalsResponse response =
+        axonflow.getPendingPlanApprovals(0, "plan a&b");
+
+    assertThat(response.getCount()).isEqualTo(0);
+  }
+
+  @Test
   @DisplayName("getPendingPlanApprovalsAsync should return future")
   void getPendingPlanApprovalsAsyncShouldReturnFuture() throws Exception {
     stubFor(

--- a/src/test/java/com/getaxonflow/sdk/types/workflow/WCPApprovalTypesTest.java
+++ b/src/test/java/com/getaxonflow/sdk/types/workflow/WCPApprovalTypesTest.java
@@ -269,9 +269,9 @@ class WCPApprovalTypesTest {
     PendingApprovalsResponse response =
         new PendingApprovalsResponse(Collections.singletonList(approval), 1);
 
-    assertThat(response.getApprovals()).hasSize(1);
-    assertThat(response.getTotal()).isEqualTo(1);
-    assertThat(response.getApprovals().get(0).getWorkflowId()).isEqualTo("wf-1");
+    assertThat(response.getPendingApprovals()).hasSize(1);
+    assertThat(response.getCount()).isEqualTo(1);
+    assertThat(response.getPendingApprovals().get(0).getWorkflowId()).isEqualTo("wf-1");
   }
 
   @Test
@@ -279,8 +279,8 @@ class WCPApprovalTypesTest {
   void pendingApprovalsResponseShouldHandleNullList() {
     PendingApprovalsResponse response = new PendingApprovalsResponse(null, 0);
 
-    assertThat(response.getApprovals()).isEmpty();
-    assertThat(response.getTotal()).isEqualTo(0);
+    assertThat(response.getPendingApprovals()).isEmpty();
+    assertThat(response.getCount()).isEqualTo(0);
   }
 
   @Test
@@ -288,20 +288,21 @@ class WCPApprovalTypesTest {
   void pendingApprovalsResponseShouldDeserialize() throws Exception {
     String json =
         "{"
-            + "\"approvals\":["
+            + "\"pending_approvals\":["
             + "  {\"workflow_id\":\"wf-1\",\"workflow_name\":\"Review\","
-            + "   \"step_id\":\"s-1\",\"step_name\":\"Generate\","
-            + "   \"step_type\":\"llm_call\",\"created_at\":\"2026-02-07T10:00:00Z\"}"
+            + "   \"step_id\":\"s-1\",\"step_index\":0,\"step_name\":\"Generate\","
+            + "   \"step_type\":\"llm_call\",\"decision\":\"require_approval\","
+            + "   \"created_at\":\"2026-02-07T10:00:00Z\"}"
             + "],"
-            + "\"total\":1"
+            + "\"count\":1"
             + "}";
 
     PendingApprovalsResponse response =
         objectMapper.readValue(json, PendingApprovalsResponse.class);
 
-    assertThat(response.getApprovals()).hasSize(1);
-    assertThat(response.getTotal()).isEqualTo(1);
-    assertThat(response.getApprovals().get(0).getWorkflowId()).isEqualTo("wf-1");
+    assertThat(response.getPendingApprovals()).hasSize(1);
+    assertThat(response.getCount()).isEqualTo(1);
+    assertThat(response.getPendingApprovals().get(0).getWorkflowId()).isEqualTo("wf-1");
   }
 
   @Test
@@ -314,7 +315,7 @@ class WCPApprovalTypesTest {
     assertThatThrownBy(
             () ->
                 response
-                    .getApprovals()
+                    .getPendingApprovals()
                     .add(
                         new PendingApproval(
                             "wf-2", "N", "s-2", "S", "tool_call", "2026-02-07T11:00:00Z")))
@@ -341,7 +342,7 @@ class WCPApprovalTypesTest {
     PendingApprovalsResponse response = new PendingApprovalsResponse(Collections.emptyList(), 0);
     String str = response.toString();
 
-    assertThat(str).contains("total=0");
-    assertThat(str).contains("approvals=");
+    assertThat(str).contains("count=0");
+    assertThat(str).contains("pendingApprovals=");
   }
 }


### PR DESCRIPTION
## Summary

- Extend \`WorkflowTypes.ApproveStepResponse\` / \`.RejectStepResponse\` with the v7.4.0 platform fields: \`decision\`, \`reason\`, \`approvalStatus\`, \`approvalId\`, approver identity, \`policiesMatched\`, \`retryContext\`, \`message\`, \`planId\`.
- Back-compat 3-arg constructors (\`new ApproveStepResponse(workflowId, stepId, status)\`) preserved so existing test fixtures keep compiling.
- Same types work across both the WCP and MAP approve/reject endpoints.

Paired with axonflow-enterprise#1678. **Do not merge** until platform merges.

## Test plan

- [x] \`./mvnw test\` — 1192 tests pass
- [x] Existing \`WCPApprovalTypesTest\` fixtures use the 3-arg back-compat constructor
- [ ] Live verification against v7.4.0 platform (release-prep session)