### PR TITLE
docs(contrib): add CONTRIBUTING.md with baseline burndown policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing! Please open an issue or pull reques
 ./mvnw verify
 ```
 
-Tests run under JUnit 5. Wire-shape contract validation lives under `scripts/wire_shape/` and runs in CI on every PR.
+Tests run under JUnit 5. The wire-shape contract gate (under `scripts/wire_shape/`) runs in CI when a PR touches Java sources, the wire-shape baseline, or the gate scripts themselves — see `.github/workflows/wire-shape-contract.yml` for the exact path filter.
 
 ## Pull request guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to AxonFlow Java SDK
+
+Thank you for your interest in contributing! Please open an issue or pull request via the [GitHub repository](https://github.com/getaxonflow/axonflow-sdk-java).
+
+## Development setup
+
+```bash
+./mvnw verify
+```
+
+Tests run under JUnit 5. Wire-shape contract validation lives under `scripts/wire_shape/` and runs in CI on every PR.
+
+## Pull request guidelines
+
+1. Keep PRs focused — one feature or fix per PR.
+2. Update `CHANGELOG.md` under `[Unreleased]` for user-visible changes.
+3. Ensure `./mvnw verify` is green and the wire-shape contract gate passes.
+4. Prefer Jackson `@JsonProperty` on a `@JsonCreator` constructor for any new wire-bound POJO field — that propagates serialization both ways without hand-rolled transformer code.
+
+## Baseline burndown policy
+
+The wire-shape contract gate uses a baseline file (`tests/fixtures/wire-shape-baseline.json`) to grandfather pre-existing drift findings — the gate fails on any *new* drift but tolerates the listed entries. The baseline exists to land the gate without a giant cleanup PR; it is not intended to be permanent.
+
+When your PR touches a type listed in the baseline, do one of:
+
+- **Burn it down.** Realign the POJO with the OpenAPI spec in this PR, regenerate the baseline via `scripts/wire_shape/refresh.py`, and note "burndown: `<entry>`" in the PR description.
+- **Justify it.** If the drift can't be resolved in this PR (different scope, blocked on a platform spec change, etc.), say so in the PR description in one line.
+
+CI does not block PRs that touch a baselined type without addressing it, but reviewers will ask the burndown-or-justify question.
+
+## Questions
+
+- Open a GitHub issue
+- Email: hello@getaxonflow.com


### PR DESCRIPTION
## Summary

Adds a baseline burndown policy section to CONTRIBUTING.md so reviewers and contributors share an expectation about what to do when a PR touches a baselined area.

The wire-shape contract gate (and the new transformer-coverage / falsey-clobber gates where applicable) accept a baseline file of grandfathered findings. Without a written policy, baselined entries linger indefinitely; with one, every PR that touches a baselined area either burns the entry down or explicitly justifies why it can't.

Doc-only change. No code.

## Test plan

- [x] CONTRIBUTING.md renders correctly on GitHub
- [x] Wording matches the gate file paths in this repo