### PR TITLE
docs(readme): replace stale Architecture Overview video with 3 canonical videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ This SDK is a client library for interacting with a running AxonFlow control pla
 
 A deployed AxonFlow platform (self-hosted or cloud) is required for end-to-end AI governance. SDKs alone are not sufficient—the platform and SDKs are designed to be used together.
 
-### Architecture Overview (2 min)
+### See AxonFlow in Action
 
-If you're new to AxonFlow, this short video shows how the control plane and SDKs work together in a real production setup:
+Three short videos covering different angles of the platform:
 
-[![AxonFlow Architecture Overview](https://img.youtube.com/vi/WwQXHKuZhxc/maxresdefault.jpg)](https://youtu.be/WwQXHKuZhxc)
-
-▶️ [Watch on YouTube](https://youtu.be/WwQXHKuZhxc)
+- **[Community Quickstart Demo (Code + Terminal, 2.5 min)](https://youtu.be/BSqU1z0xxCo)** — governed calls, PII block, Gateway Mode with LangChain/CrewAI, and MAP from YAML
+- **[Runtime Control Demo (Portal + Workflow, 3 min)](https://youtu.be/6UatGpn7KwE)** — approvals, retry safety, execution state, and the audit viewer
+- **[Architecture Deep Dive (12 min)](https://youtu.be/Q2CZ1qnquhg)** — how the control plane works, policy enforcement flow, and multi-agent planning
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

Replaces the single mislabelled "Architecture Overview (2 min)" video block (`WwQXHKuZhxc`) with a **See AxonFlow in Action** section linking the three canonical demo videos used across `axonflow/README.md` and `docs.getaxonflow.com/docs/getting-started`:

- **Community Quickstart Demo (Code + Terminal, 2.5 min)** — `BSqU1z0xxCo` — governed calls, PII block, Gateway Mode, MAP from YAML
- **Runtime Control Demo (Portal + Workflow, 3 min)** — `6UatGpn7KwE` — approvals, retry safety, execution state, audit viewer
- **Architecture Deep Dive (12 min)** — `Q2CZ1qnquhg` — control plane, policy enforcement flow, multi-agent planning

The `WwQXHKuZhxc` video was only ever linked from the four SDK READMEs (never from community / docs / landing), and the "Architecture Overview" label was inaccurate per the campaign content review on 2026-04-26.

## Test plan
- [ ] Render preview: 3 video bullet points appear in place of the old thumbnail block
- [ ] All 3 YouTube URLs resolve