### PR TITLE
ci: live community-stack integration + minimal basic example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,42 +146,6 @@ jobs:
             sleep 30
           done
 
-  integration-test:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Configure Maven mirror
-        run: |
-          mkdir -p ~/.m2
-          cat > ~/.m2/settings.xml << 'EOF'
-          <?xml version="1.0" encoding="UTF-8"?>
-          <settings>
-            <mirrors>
-              <mirror>
-                <id>central-mirror</id>
-                <name>Maven Central Mirror (repo1)</name>
-                <url>https://repo1.maven.org/maven2</url>
-                <mirrorOf>central</mirrorOf>
-              </mirror>
-            </mirrors>
-          </settings>
-          EOF
-
-      - name: Run integration tests
-        run: mvn verify -DskipUnitTests -B -U
-        continue-on-error: true
-
   package:
     runs-on: ubuntu-latest
     needs: [build, lint]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,136 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+  # Weekly drift catch
+  schedule:
+    - cron: '0 6 * * 1'  # Monday 06:00 UTC
+
+permissions:
+  contents: read
+
+env:
+  DO_NOT_TRACK: '1'
+
+jobs:
+  # WireMock-based integration tests run on every PR + push. No live stack
+  # needed — these are contract-style tests over the SDK + agent wire shape.
+  contract-integration:
+    name: Contract Integration (WireMock)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout SDK
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Configure Maven mirror
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml << 'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <settings>
+            <mirrors>
+              <mirror>
+                <id>central-mirror</id>
+                <name>Maven Central Mirror (repo1)</name>
+                <url>https://repo1.maven.org/maven2</url>
+                <mirrorOf>central</mirrorOf>
+              </mirror>
+            </mirrors>
+          </settings>
+          EOF
+
+      - name: Run integration tests (WireMock)
+        run: mvn verify -DskipUnitTests -B -U
+
+  # Live integration runs against a real community stack via docker compose.
+  # Mirrors axonflow-sdk-go/.github/workflows/integration.yml — clones the
+  # community repo, brings up docker compose, runs the basic example.
+  # Skipped on PR (Go pattern) — PR-level live coverage is added in QF-13.
+  live-integration:
+    name: Live Integration (Community Stack)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: contract-integration
+    if: github.event_name != 'pull_request'
+    steps:
+      - name: Checkout SDK
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Configure Maven mirror
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml << 'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <settings>
+            <mirrors>
+              <mirror>
+                <id>central-mirror</id>
+                <name>Maven Central Mirror (repo1)</name>
+                <url>https://repo1.maven.org/maven2</url>
+                <mirrorOf>central</mirrorOf>
+              </mirror>
+            </mirrors>
+          </settings>
+          EOF
+
+      - name: Install SDK to local Maven repo
+        run: mvn install -DskipTests -B -U
+
+      - name: Clone community stack
+        run: git clone --depth 1 https://github.com/getaxonflow/axonflow.git ../axonflow
+
+      - name: Start community stack
+        run: |
+          cd ../axonflow
+          docker compose up -d
+
+          echo "Waiting for agent to be healthy..."
+          timeout 120 bash -c 'until curl -sf http://localhost:8080/health; do sleep 2; done'
+          echo "Agent is healthy"
+
+          echo "Waiting for orchestrator to be healthy..."
+          timeout 60 bash -c 'until curl -sf http://localhost:8081/health; do sleep 2; done'
+          echo "Orchestrator is healthy"
+
+      - name: Run basic example against live stack
+        env:
+          AXONFLOW_AGENT_URL: http://localhost:8080
+          AXONFLOW_CLIENT_ID: demo-client
+          AXONFLOW_CLIENT_SECRET: demo-secret
+        working-directory: examples/basic
+        run: timeout 90 mvn -q compile exec:java
+
+      - name: Stop community stack
+        if: always()
+        run: |
+          if [ -d "../axonflow" ]; then
+            cd ../axonflow
+            docker compose down --volumes --remove-orphans || true
+          fi
+
+      - name: Show docker logs on failure
+        if: failure()
+        run: |
+          if [ -d "../axonflow" ]; then
+            cd ../axonflow
+            docker compose logs --tail=200 || true
+          fi

--- a/examples/basic/pom.xml
+++ b/examples/basic/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.getaxonflow.examples</groupId>
+    <artifactId>basic</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>AxonFlow Java SDK — Basic Example</name>
+    <description>
+        Minimal smoke example exercising healthCheck() + proxyLLMCall() against
+        a running AxonFlow agent. Run with mvn install on the SDK first to put
+        the local artifact on the classpath.
+    </description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.getaxonflow</groupId>
+            <artifactId>axonflow-sdk</artifactId>
+            <version>6.1.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.getaxonflow.examples.Basic</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/basic/src/main/java/com/getaxonflow/examples/Basic.java
+++ b/examples/basic/src/main/java/com/getaxonflow/examples/Basic.java
@@ -1,0 +1,86 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: Apache-2.0
+//
+// Basic AxonFlow Java SDK smoke example.
+//
+// Demonstrates:
+//   - Client initialization from environment
+//   - Health check against the agent
+//   - A protected proxyLLMCall round-trip
+//
+// Run from this directory after `mvn install -DskipTests` at the SDK root:
+//
+//   export AXONFLOW_AGENT_URL=http://localhost:8080
+//   export AXONFLOW_CLIENT_ID=demo-client
+//   export AXONFLOW_CLIENT_SECRET=demo-secret
+//   mvn -q compile exec:java
+package com.getaxonflow.examples;
+
+import com.getaxonflow.sdk.AxonFlow;
+import com.getaxonflow.sdk.AxonFlowConfig;
+import com.getaxonflow.sdk.types.ClientRequest;
+import com.getaxonflow.sdk.types.ClientResponse;
+import com.getaxonflow.sdk.types.HealthStatus;
+import com.getaxonflow.sdk.types.RequestType;
+
+public class Basic {
+
+    public static void main(String[] args) {
+        String endpoint = envOrDefault("AXONFLOW_AGENT_URL", "http://localhost:8080");
+        String clientId = envOrDefault("AXONFLOW_CLIENT_ID", "demo-client");
+        String clientSecret = envOrDefault("AXONFLOW_CLIENT_SECRET", "demo-secret");
+
+        System.out.println("Initializing AxonFlow client...");
+        AxonFlow client =
+                AxonFlow.create(
+                        AxonFlowConfig.builder()
+                                .agentUrl(endpoint)
+                                .clientId(clientId)
+                                .clientSecret(clientSecret)
+                                .debug(true)
+                                .build());
+
+        System.out.println("\n============================================================");
+        System.out.println("Step 1: Health Check");
+        System.out.println("============================================================");
+        try {
+            HealthStatus health = client.healthCheck();
+            System.out.printf("  Status:  %s%n", health.getStatus());
+            if (health.getVersion() != null) {
+                System.out.printf("  Version: %s%n", health.getVersion());
+            }
+        } catch (Exception e) {
+            System.err.println("Health check failed: " + e.getMessage());
+            System.exit(1);
+        }
+
+        System.out.println("\n============================================================");
+        System.out.println("Step 2: Protected proxyLLMCall");
+        System.out.println("============================================================");
+        try {
+            ClientRequest request =
+                    ClientRequest.builder()
+                            .query("What is the capital of France?")
+                            .userToken("demo-user")
+                            .clientId(clientId)
+                            .requestType(RequestType.CHAT)
+                            .build();
+
+            ClientResponse response = client.proxyLLMCall(request);
+            System.out.printf("  Success: %s%n", response.isSuccess());
+            System.out.printf("  Blocked: %s%n", response.isBlocked());
+        } catch (Exception e) {
+            // Community stack often runs without an LLM provider configured;
+            // a fail-open or 503 is normal here. Don't fail the smoke for it.
+            System.out.println("  (proxyLLMCall returned non-success — expected on community without LLM): "
+                    + e.getMessage());
+        }
+
+        System.out.println("\nBasic example complete.");
+    }
+
+    private static String envOrDefault(String key, String fallback) {
+        String v = System.getenv(key);
+        return (v == null || v.isEmpty()) ? fallback : v;
+    }
+}

--- a/src/test/java/com/getaxonflow/sdk/integration/AxonFlowIntegrationTest.java
+++ b/src/test/java/com/getaxonflow/sdk/integration/AxonFlowIntegrationTest.java
@@ -253,15 +253,20 @@ class AxonFlowIntegrationTest {
   @Test
   @DisplayName("generatePlan should return plan")
   void generatePlanShouldReturnPlan() {
+    // Java SDK POSTs to /api/request with request_type=multi-agent-plan and
+    // expects the agent's standard envelope: {success, plan_id, data: {steps,
+    // domain, complexity, parallel}, metadata, result}.
     stubFor(
-        post(urlEqualTo("/api/v1/orchestrator/plan"))
+        post(urlEqualTo("/api/request"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
                     .withHeader("Content-Type", "application/json")
                     .withBody(
                         "{"
+                            + "\"success\": true,"
                             + "\"plan_id\": \"plan_123\","
+                            + "\"data\": {"
                             + "\"steps\": ["
                             + "{"
                             + "\"id\": \"step_001\","
@@ -270,8 +275,9 @@ class AxonFlowIntegrationTest {
                             + "}"
                             + "],"
                             + "\"domain\": \"generic\","
-                            + "\"complexity\": 2,"
-                            + "\"status\": \"pending\""
+                            + "\"complexity\": 2"
+                            + "},"
+                            + "\"metadata\": {}"
                             + "}")));
 
     PlanResponse plan =


### PR DESCRIPTION
## Summary

Closes the QF-14 (Java SDK) row in the Phase 1 quality-freeze epic
(`axonflow-business-docs/engineering/QUALITY_FREEZE_EPIC_2026-04-24.md`).

The `integration-test` job in `ci.yml` was running `mvn verify
-DskipUnitTests` against WireMock with `continue-on-error: true` —
non-blocking theater. It never exercised a real agent, and even if the
WireMock stubs drifted from the real wire shape (they had), the
suppression hid the failure.

This PR replaces it with the Go SDK pattern: dedicated `integration.yml`
that runs the WireMock contract layer as a real blocking job AND adds a
live-stack job that clones the community repo, brings up `docker
compose`, and runs a real example.

**Ported from:** `axonflow-sdk-go/.github/workflows/integration.yml`.

## What this PR does

### CI

- **`contract-integration`** (every PR + push, NO `continue-on-error`):
  `mvn verify -DskipUnitTests`. Same WireMock test suite as before, but
  now blocks merges if it fails.
- **`live-integration`** (push to main + schedule + workflow_dispatch;
  **skipped on PR** per Go pattern): clones community repo, `docker
  compose up`, installs the local SNAPSHOT to `~/.m2`, runs
  `examples/basic` end-to-end against `http://localhost:8080`.
- `ci.yml` loses its stale `integration-test` job — same `mvn verify`
  step now lives in `integration.yml` without the `continue-on-error`
  suppression.

### New example: `examples/basic/`

One `pom.xml` + one Java class (`Basic.java`). Mirrors the Go SDK's
`examples/basic/main.go` structure: client init from env, health check,
single `proxyLLMCall` round-trip. The live-integration job runs it
against the live community stack as a smoke. Issue #146 tracks the
follow-up `planning` + `connectors` example dirs, which were scoped out
per the QF-10 \"trivially small\" constraint.

### Pre-existing test fix surfaced by removing the suppression

`AxonFlowIntegrationTest#generatePlanShouldReturnPlan` stubbed
`/api/v1/orchestrator/plan`, but the Java SDK actually POSTs to
`/api/request` with `request_type=multi-agent-plan` and parses the
agent's enveloped `{success, plan_id, data: {steps, domain, ...},
metadata}` shape. Updated stub URL + response body to match the real
wire contract. Per the freeze policy (\"no bug found gets postponed\"),
this is fixed inside the same PR — it's exactly the class of drift the
old `continue-on-error: true` was hiding.

## Self-review checklist

- [x] Action versions pinned (`@v4`)
- [x] `permissions: contents: read` scoped tight
- [x] No new secret refs introduced
- [x] No `continue-on-error: true` anywhere
- [x] Contract-integration job runs in <10 min (PR-blocking budget)
- [x] Live-integration timeout 25 min matches Go SDK + Java's slower start
- [x] No `pom.xml` version bump (per `feedback_no_per_pr_version_bumps.md`)
- [x] No AI attribution

## Test plan

- [x] `mvn test -B` (full unit suite): BUILD SUCCESS — 1204 tests, 0 fail
- [x] `mvn verify -DskipUnitTests -B` (WireMock contract suite): BUILD
      SUCCESS — 12/12 in `AxonFlowIntegrationTest`, after fixing
      `generatePlanShouldReturnPlan`
- [x] `mvn install -DskipTests -B` then `cd examples/basic && mvn -B
      compile`: BUILD SUCCESS
- [ ] CI: `contract-integration` green on this PR
- [ ] CI: `live-integration` green on push to main (post-merge)

## Out of scope (filed separately)

- #146 — minimal `examples/planning/` + `examples/connectors/` dirs