### PR TITLE
ci: fix version-sync assertion (no-op rewrite is fine)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -141,18 +141,24 @@ jobs:
           echo "Parent SDK version: ${PARENT_VERSION}"
           # Replace the axonflow-sdk dependency version in examples/basic/pom.xml.
           # Anchored on the artifactId on the previous line to avoid touching
-          # other deps.
+          # other deps. Asserts the regex matched (count >= 1) so a layout
+          # drift fails CI loud; a no-op rewrite (versions already match)
+          # is fine.
           python3 - <<PY
           import re, pathlib
           p = pathlib.Path("examples/basic/pom.xml")
           s = p.read_text()
-          new = re.sub(
+          new, count = re.subn(
               r"(<artifactId>axonflow-sdk</artifactId>\s*<version>)[^<]+(</version>)",
               rf"\g<1>${PARENT_VERSION}\g<2>",
               s,
           )
-          assert new != s, "Failed to rewrite example pom version"
-          p.write_text(new)
+          assert count >= 1, "Regex did not match — examples/basic/pom.xml layout drifted"
+          if new != s:
+              p.write_text(new)
+              print(f"Rewrote example pom version to ${PARENT_VERSION}")
+          else:
+              print(f"Example pom already at parent version ${PARENT_VERSION} (no-op)")
           PY
           grep -A 1 "axonflow-sdk" examples/basic/pom.xml | head -4
 


### PR DESCRIPTION
## Summary

Post-merge run of #149 on main hit the version-sync assertion immediately:

\`\`\`
AssertionError: Failed to rewrite example pom version
\`\`\`

The assertion was \`assert new != s\` — fires when parent and example versions already agree (rewrite is an identity no-op). The parent is at 6.1.0 and the example was already pinned to 6.1.0, so the regex matched 1 occurrence but the content was unchanged.

## Fix

Use \`re.subn\` to count matches and assert \`count >= 1\`. A no-op rewrite (versions already match) is the expected steady state; a zero-match means the pom layout drifted and CI should fail loud.

## Test plan

- [x] Local rerun of the inlined script with synthetic pom — assertion fires only when regex doesn't match
- [ ] CI: contract-integration green
- [ ] CI: live-integration green on push to main (the version-sync step now succeeds; the basic example smoke runs)