### PR TITLE
hack-cleanup: AxonFlowException catch + Maven mirror composite action

### DIFF
--- a/.github/actions/setup-maven/action.yml
+++ b/.github/actions/setup-maven/action.yml
@@ -1,0 +1,25 @@
+name: Setup Maven mirror
+description: |
+  Configure ~/.m2/settings.xml with the Maven Central repo1 mirror. Used by
+  every Maven CI job to pin against the same fast mirror and avoid the
+  occasional Maven Central CDN flake the SDK builds have hit historically.
+runs:
+  using: composite
+  steps:
+    - name: Configure Maven mirror
+      shell: bash
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml << 'EOF'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <settings>
+          <mirrors>
+            <mirror>
+              <id>central-mirror</id>
+              <name>Maven Central Mirror (repo1)</name>
+              <url>https://repo1.maven.org/maven2</url>
+              <mirrorOf>central</mirrorOf>
+            </mirror>
+          </mirrors>
+        </settings>
+        EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,21 +32,7 @@ jobs:
           cache: 'maven'
 
       - name: Configure Maven mirror
-        run: |
-          mkdir -p ~/.m2
-          cat > ~/.m2/settings.xml << 'EOF'
-          <?xml version="1.0" encoding="UTF-8"?>
-          <settings>
-            <mirrors>
-              <mirror>
-                <id>central-mirror</id>
-                <name>Maven Central Mirror (repo1)</name>
-                <url>https://repo1.maven.org/maven2</url>
-                <mirrorOf>central</mirrorOf>
-              </mirror>
-            </mirrors>
-          </settings>
-          EOF
+        uses: ./.github/actions/setup-maven
 
       - name: Build with Maven
         run: |
@@ -113,21 +99,7 @@ jobs:
           cache: 'maven'
 
       - name: Configure Maven mirror
-        run: |
-          mkdir -p ~/.m2
-          cat > ~/.m2/settings.xml << 'EOF'
-          <?xml version="1.0" encoding="UTF-8"?>
-          <settings>
-            <mirrors>
-              <mirror>
-                <id>central-mirror</id>
-                <name>Maven Central Mirror (repo1)</name>
-                <url>https://repo1.maven.org/maven2</url>
-                <mirrorOf>central</mirrorOf>
-              </mirror>
-            </mirrors>
-          </settings>
-          EOF
+        uses: ./.github/actions/setup-maven
 
       - name: Check code formatting
         run: |
@@ -162,21 +134,7 @@ jobs:
           cache: 'maven'
 
       - name: Configure Maven mirror
-        run: |
-          mkdir -p ~/.m2
-          cat > ~/.m2/settings.xml << 'EOF'
-          <?xml version="1.0" encoding="UTF-8"?>
-          <settings>
-            <mirrors>
-              <mirror>
-                <id>central-mirror</id>
-                <name>Maven Central Mirror (repo1)</name>
-                <url>https://repo1.maven.org/maven2</url>
-                <mirrorOf>central</mirrorOf>
-              </mirror>
-            </mirrors>
-          </settings>
-          EOF
+        uses: ./.github/actions/setup-maven
 
       - name: Package JAR
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,21 +47,7 @@ jobs:
           cache: 'maven'
 
       - name: Configure Maven mirror
-        run: |
-          mkdir -p ~/.m2
-          cat > ~/.m2/settings.xml << 'EOF'
-          <?xml version="1.0" encoding="UTF-8"?>
-          <settings>
-            <mirrors>
-              <mirror>
-                <id>central-mirror</id>
-                <name>Maven Central Mirror (repo1)</name>
-                <url>https://repo1.maven.org/maven2</url>
-                <mirrorOf>central</mirrorOf>
-              </mirror>
-            </mirrors>
-          </settings>
-          EOF
+        uses: ./.github/actions/setup-maven
 
       # `-DskipUnitTests=true` is now a real toggle (bound to surefire's
       # <skipTests> via pom.xml); previously it was a no-op flag and unit
@@ -103,21 +89,7 @@ jobs:
           cache: 'maven'
 
       - name: Configure Maven mirror
-        run: |
-          mkdir -p ~/.m2
-          cat > ~/.m2/settings.xml << 'EOF'
-          <?xml version="1.0" encoding="UTF-8"?>
-          <settings>
-            <mirrors>
-              <mirror>
-                <id>central-mirror</id>
-                <name>Maven Central Mirror (repo1)</name>
-                <url>https://repo1.maven.org/maven2</url>
-                <mirrorOf>central</mirrorOf>
-              </mirror>
-            </mirrors>
-          </settings>
-          EOF
+        uses: ./.github/actions/setup-maven
 
       # 3-attempt retry for transient Maven Central flakes — same pattern
       # ci.yml's `Build with Maven` and `Run unit tests` use.

--- a/examples/basic/src/main/java/com/getaxonflow/examples/Basic.java
+++ b/examples/basic/src/main/java/com/getaxonflow/examples/Basic.java
@@ -20,6 +20,7 @@ package com.getaxonflow.examples;
 import com.getaxonflow.sdk.AxonFlow;
 import com.getaxonflow.sdk.AxonFlowConfig;
 import com.getaxonflow.sdk.exceptions.AuthenticationException;
+import com.getaxonflow.sdk.exceptions.AxonFlowException;
 import com.getaxonflow.sdk.exceptions.ConnectionException;
 import com.getaxonflow.sdk.exceptions.PolicyViolationException;
 import com.getaxonflow.sdk.types.ClientRequest;
@@ -108,9 +109,9 @@ public class Basic {
             // These are real failures: bad creds or stack down. Fail loud.
             System.err.println("proxyLLMCall failed: " + e.getMessage());
             System.exit(1);
-        } catch (RuntimeException e) {
-            // Other runtime failures (e.g. agent returns non-2xx because no
-            // LLM provider is configured) — log and continue. Tightening
+        } catch (AxonFlowException e) {
+            // Other SDK-level failures (e.g. agent returns non-2xx because
+            // no LLM provider is configured) — log and continue. Tightening
             // this further requires capability detection from /health,
             // tracked in axonflow-sdk-java#146.
             System.out.println("  proxyLLMCall non-success: " + e.getMessage());
@@ -131,7 +132,7 @@ public class Basic {
         } catch (AuthenticationException | ConnectionException e) {
             System.err.println("listConnectors failed: " + e.getMessage());
             System.exit(1);
-        } catch (RuntimeException e) {
+        } catch (AxonFlowException e) {
             System.out.println("  listConnectors non-success: " + e.getMessage());
         }
     }


### PR DESCRIPTION
## Summary

Honest hack-cleanup PR. When the user asked \"did you make any hacks/shortcuts during the QF-14 review work?\", two leftover items from the deep review:

1. **`Basic.java` caught `RuntimeException`** for the community-fail-open path (the catch block in #149's review-fixes was tighter than the original `Exception`, but still over-broad). The SDK exception hierarchy is rooted at `AxonFlowException extends RuntimeException` — catching `RuntimeException` would have swallowed any non-SDK runtime error (NullPointerException from a SDK regression, IllegalStateException from a misuse, etc.) and printed it as \"non-success\". Tightened to `AxonFlowException`.

2. **Maven mirror config duplicated 5 times** across `ci.yml` (3 jobs) + `integration.yml` (2 jobs). Reviewer flagged it as P2 polish. Extracted to a composite action `.github/actions/setup-maven`. ~65 lines of YAML duplication removed; if the mirror URL ever rotates, one change instead of five.

## Test plan

- [x] `mvn install -DskipTests -B` clean (parent + example)
- [x] `cd examples/basic && mvn -B compile` clean
- [ ] CI green on all jobs (composite action resolves correctly)
- [ ] Live integration green on push to main

## What I'm not changing

- The `wcp-retry-idempotency` example pin to SDK 5.5.0 — known stale per `feedback_stale_replace_paths_in_examples.md`. Bulk-bump sweeps deliberately skip these. The example still builds against 5.5.0 and the live-integration job only runs `examples/basic`, not this one.
- The basic example's `proxyLLMCall` exit semantics on community-without-LLM. Tightening further requires capability detection from `/health` (which the agent already publishes), tracked in #146.