### PR TITLE
fix(telemetry)!: remove DO_NOT_TRACK opt-out (BREAKING)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  DO_NOT_TRACK: '1'
+  AXONFLOW_TELEMETRY: 'off'
 
 jobs:
   build:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DO_NOT_TRACK: '1'
+  AXONFLOW_TELEMETRY: 'off'
 
 jobs:
   # WireMock-based integration tests run on every PR + push. No live stack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 env:
-  DO_NOT_TRACK: '1'
+  AXONFLOW_TELEMETRY: 'off'
 
 jobs:
   # Preflight: validate CHANGELOG has a section for the tag being released

--- a/.github/workflows/validate-version-alignment.yml
+++ b/.github/workflows/validate-version-alignment.yml
@@ -29,7 +29,7 @@ permissions:
   contents: read
 
 env:
-  DO_NOT_TRACK: '1'
+  AXONFLOW_TELEMETRY: 'off'
 
 jobs:
   validate-versions:

--- a/.github/workflows/wire-shape-contract.yml
+++ b/.github/workflows/wire-shape-contract.yml
@@ -38,7 +38,7 @@ jobs:
     name: Validate Wire Shape
     runs-on: ubuntu-latest
     env:
-      DO_NOT_TRACK: '1'
+      AXONFLOW_TELEMETRY: 'off'
     steps:
       - name: Checkout SDK (full history for SHA-bump guard)
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING:** `DO_NOT_TRACK` is no longer honored as an AxonFlow telemetry opt-out. Use `AXONFLOW_TELEMETRY=off` instead.
+
+  `DO_NOT_TRACK` was deprecated because it is commonly inherited from host tools and developer environments (CLIs like Codex and Claude Code inject it unconditionally), which makes it an unreliable expression of user intent for AxonFlow telemetry.
+
+- **BREAKING (test API):** Package-private `TelemetryReporter.isEnabled` and `TelemetryReporter.sendPing` overloads no longer accept a `String doNotTrack` parameter. The remaining `String axonflowTelemetry` parameter is the sole opt-out signal accepted by the testability surface.
+
+### Fixed
+
+- The one-line `DO_NOT_TRACK=1 is deprecated...` `logger.warn` is no longer emitted. Removing the warning eliminates log noise that previously appeared on every telemetry decision when `DO_NOT_TRACK=1` was set.
+
+### CI / development
+
+- CI workflows (`ci.yml`, `integration.yml`, `release.yml`, `wire-shape-contract.yml`, `validate-version-alignment.yml`) now use `AXONFLOW_TELEMETRY=off` to suppress telemetry during automated runs.
+
+
 ## [6.2.0] - 2026-04-28 — listLLMProviders() + LLMProvider source-compat
 
 Minor release. New LLM-provider listing API closes the parity gap with the Python + Go SDKs; the rest of the cycle restores `LLMProvider` source-compatibility for callers using the 7-arg primitive shape. Coordinated cycle: TypeScript v6.2.0 / Python v6.9.0 / Go v6.0.0 (major: see SDKCompatibility breaking type change in that release) ship same day.

--- a/README.md
+++ b/README.md
@@ -600,7 +600,10 @@ For enterprise features, contact [sales@getaxonflow.com](mailto:sales@getaxonflo
 ## Telemetry
 
 This SDK sends anonymous usage telemetry (SDK version, OS, enabled features) to help improve AxonFlow.
-No prompts, payloads, or PII are ever collected. Opt out: `AXONFLOW_TELEMETRY=off` or `DO_NOT_TRACK=1`.
+No prompts, payloads, or PII are ever collected. Opt out: `AXONFLOW_TELEMETRY=off`.
+
+`DO_NOT_TRACK` is **not** honored as an opt-out for AxonFlow telemetry. It is commonly inherited from host tools and developer environments, which makes it an unreliable expression of user intent.
+
 See [Telemetry Documentation](https://docs.getaxonflow.com/docs/telemetry) for full details.
 
 ## Contributing

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
                         <exclude>**/*IntegrationTest.java</exclude>
                     </excludes>
                     <environmentVariables>
-                        <DO_NOT_TRACK>1</DO_NOT_TRACK>
+                        <AXONFLOW_TELEMETRY>off</AXONFLOW_TELEMETRY>
                     </environmentVariables>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,9 @@
                         <include>**/*IT.java</include>
                         <include>**/*IntegrationTest.java</include>
                     </includes>
+                    <environmentVariables>
+                        <AXONFLOW_TELEMETRY>off</AXONFLOW_TELEMETRY>
+                    </environmentVariables>
                 </configuration>
             </plugin>
 

--- a/src/main/java/com/getaxonflow/sdk/AxonFlowConfig.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlowConfig.java
@@ -514,8 +514,8 @@ public final class AxonFlowConfig {
      * <p>{@code null} (default) uses the mode-based default: ON for production, OFF for sandbox.
      * {@code Boolean.TRUE} forces telemetry on, {@code Boolean.FALSE} forces it off.
      *
-     * <p>Telemetry can also be disabled globally via environment variables: {@code DO_NOT_TRACK=1}
-     * or {@code AXONFLOW_TELEMETRY=off}.
+     * <p>Telemetry can also be disabled globally via environment variable
+     * {@code AXONFLOW_TELEMETRY=off}.
      *
      * @param telemetry true to enable, false to disable, null for default behavior
      * @return this builder

--- a/src/main/java/com/getaxonflow/sdk/telemetry/TelemetryReporter.java
+++ b/src/main/java/com/getaxonflow/sdk/telemetry/TelemetryReporter.java
@@ -44,7 +44,6 @@ import org.slf4j.LoggerFactory;
  * <p>Telemetry can be disabled via:
  *
  * <ul>
- *   <li>Setting environment variable {@code DO_NOT_TRACK=1}
  *   <li>Setting environment variable {@code AXONFLOW_TELEMETRY=off}
  *   <li>Setting {@code telemetry(false)} on the config builder
  * </ul>
@@ -87,7 +86,6 @@ public class TelemetryReporter {
         telemetryEnabled,
         debug,
         hasCredentials,
-        System.getenv("DO_NOT_TRACK"),
         System.getenv("AXONFLOW_TELEMETRY"),
         System.getenv("AXONFLOW_CHECKPOINT_URL"));
   }
@@ -99,10 +97,9 @@ public class TelemetryReporter {
       Boolean telemetryEnabled,
       boolean debug,
       boolean hasCredentials,
-      String doNotTrack,
       String axonflowTelemetry,
       String checkpointUrl) {
-    if (!isEnabled(mode, telemetryEnabled, hasCredentials, doNotTrack, axonflowTelemetry)) {
+    if (!isEnabled(mode, telemetryEnabled, hasCredentials, axonflowTelemetry)) {
       if (debug) {
         logger.debug("Telemetry is disabled, skipping ping");
       }
@@ -179,14 +176,15 @@ public class TelemetryReporter {
    * <p>Priority order:
    *
    * <ol>
-   *   <li>{@code DO_NOT_TRACK=1} environment variable disables telemetry (<strong>deprecated</strong>,
-   *       removed after 2026-05-05 in the next major release; emits a one-line warning when it's
-   *       the active control so operators can migrate)
    *   <li>{@code AXONFLOW_TELEMETRY=off} environment variable disables telemetry (canonical
-   *       AxonFlow-specific opt-out)
+   *       AxonFlow-specific opt-out, always wins)
    *   <li>Config override ({@code Boolean.TRUE} or {@code Boolean.FALSE}) takes precedence
    *   <li>Default: ON for all modes except sandbox
    * </ol>
+   *
+   * <p>{@code DO_NOT_TRACK} is intentionally NOT honored. It is commonly inherited from host
+   * tools and developer environments (CLIs like Codex and Claude Code inject it unconditionally),
+   * which makes it an unreliable expression of user intent for AxonFlow telemetry.
    *
    * @param mode the deployment mode
    * @param configOverride explicit config override (null = use default)
@@ -196,34 +194,12 @@ public class TelemetryReporter {
    */
   static boolean isEnabled(String mode, Boolean configOverride, boolean hasCredentials) {
     return isEnabled(
-        mode,
-        configOverride,
-        hasCredentials,
-        System.getenv("DO_NOT_TRACK"),
-        System.getenv("AXONFLOW_TELEMETRY"));
+        mode, configOverride, hasCredentials, System.getenv("AXONFLOW_TELEMETRY"));
   }
 
   /** Package-private for testing. Accepts env var values as parameters. */
   static boolean isEnabled(
-      String mode,
-      Boolean configOverride,
-      boolean hasCredentials,
-      String doNotTrack,
-      String axonflowTelemetry) {
-    if (doNotTrack != null && "1".equals(doNotTrack.trim())) {
-      // Only warn when DO_NOT_TRACK is the active control. If AXONFLOW_TELEMETRY=off is also set,
-      // the caller has already migrated.
-      boolean alreadyMigrated =
-          axonflowTelemetry != null && "off".equalsIgnoreCase(axonflowTelemetry.trim());
-      if (!alreadyMigrated) {
-        logger.warn(
-            "DO_NOT_TRACK=1 is deprecated as an AxonFlow telemetry opt-out and will be removed"
-                + " after 2026-05-05 in the next major release. Set AXONFLOW_TELEMETRY=off to opt"
-                + " out going forward. See https://docs.getaxonflow.com/docs/telemetry for"
-                + " details.");
-      }
-      return false;
-    }
+      String mode, Boolean configOverride, boolean hasCredentials, String axonflowTelemetry) {
     if (axonflowTelemetry != null && "off".equalsIgnoreCase(axonflowTelemetry.trim())) {
       return false;
     }

--- a/src/test/java/com/getaxonflow/sdk/telemetry/TelemetryReporterShortLivedTest.java
+++ b/src/test/java/com/getaxonflow/sdk/telemetry/TelemetryReporterShortLivedTest.java
@@ -67,7 +67,6 @@ class TelemetryReporterShortLivedTest {
         Boolean.TRUE,
         false,
         false,
-        null, // DO_NOT_TRACK
         null, // AXONFLOW_TELEMETRY
         checkpointUrl);
     long elapsedMs = (System.nanoTime() - startNs) / 1_000_000L;

--- a/src/test/java/com/getaxonflow/sdk/telemetry/TelemetryReporterTest.java
+++ b/src/test/java/com/getaxonflow/sdk/telemetry/TelemetryReporterTest.java
@@ -33,73 +33,58 @@ class TelemetryReporterTest {
 
   private final ObjectMapper objectMapper = new ObjectMapper();
 
-  // --- isEnabled tests (using the 5-arg package-private method) ---
-
-  @Test
-  @DisplayName("should disable telemetry when DO_NOT_TRACK=1")
-  void testTelemetryDisabledByDoNotTrack() {
-    assertThat(TelemetryReporter.isEnabled("production", null, true, "1", null)).isFalse();
-    assertThat(TelemetryReporter.isEnabled("production", Boolean.TRUE, true, "1", null)).isFalse();
-    assertThat(TelemetryReporter.isEnabled("sandbox", null, true, "1", null)).isFalse();
-  }
+  // --- isEnabled tests (using the 4-arg package-private method) ---
+  // DO_NOT_TRACK is intentionally NOT honored; the 4-arg overload only takes
+  // AXONFLOW_TELEMETRY. The DNT-related tests below pin that new invariant.
 
   @Test
   @DisplayName("should disable telemetry when AXONFLOW_TELEMETRY=off")
   void testTelemetryDisabledByAxonflowEnv() {
-    assertThat(TelemetryReporter.isEnabled("production", null, true, null, "off")).isFalse();
-    assertThat(TelemetryReporter.isEnabled("production", null, true, null, "OFF")).isFalse();
-    assertThat(TelemetryReporter.isEnabled("production", Boolean.TRUE, true, null, "off"))
-        .isFalse();
+    assertThat(TelemetryReporter.isEnabled("production", null, true, "off")).isFalse();
+    assertThat(TelemetryReporter.isEnabled("production", null, true, "OFF")).isFalse();
+    assertThat(TelemetryReporter.isEnabled("production", Boolean.TRUE, true, "off")).isFalse();
   }
 
   @Test
   @DisplayName("should default telemetry OFF for sandbox mode")
   void testTelemetryDefaultOffForSandbox() {
-    assertThat(TelemetryReporter.isEnabled("sandbox", null, true, null, null)).isFalse();
+    assertThat(TelemetryReporter.isEnabled("sandbox", null, true, null)).isFalse();
   }
 
   @Test
   @DisplayName("should default telemetry ON for production mode with credentials")
   void testTelemetryDefaultOnForProductionWithCredentials() {
-    assertThat(TelemetryReporter.isEnabled("production", null, true, null, null)).isTrue();
+    assertThat(TelemetryReporter.isEnabled("production", null, true, null)).isTrue();
   }
 
   @Test
   @DisplayName("should default telemetry ON for production mode even without credentials")
   void testTelemetryDefaultOnForProductionWithoutCredentials() {
-    assertThat(TelemetryReporter.isEnabled("production", null, false, null, null)).isTrue();
+    assertThat(TelemetryReporter.isEnabled("production", null, false, null)).isTrue();
   }
 
   @Test
   @DisplayName("should default telemetry ON for enterprise mode with credentials")
   void testTelemetryDefaultOnForEnterpriseWithCredentials() {
-    assertThat(TelemetryReporter.isEnabled("enterprise", null, true, null, null)).isTrue();
+    assertThat(TelemetryReporter.isEnabled("enterprise", null, true, null)).isTrue();
   }
 
   @Test
   @DisplayName("should allow config override to enable telemetry in sandbox")
   void testTelemetryConfigOverrideEnable() {
-    assertThat(TelemetryReporter.isEnabled("sandbox", Boolean.TRUE, false, null, null)).isTrue();
+    assertThat(TelemetryReporter.isEnabled("sandbox", Boolean.TRUE, false, null)).isTrue();
   }
 
   @Test
   @DisplayName("should allow config override to disable telemetry in production")
   void testTelemetryConfigOverrideDisable() {
-    assertThat(TelemetryReporter.isEnabled("production", Boolean.FALSE, true, null, null))
-        .isFalse();
-  }
-
-  @Test
-  @DisplayName("DO_NOT_TRACK takes precedence over config override")
-  void testDoNotTrackPrecedence() {
-    assertThat(TelemetryReporter.isEnabled("production", Boolean.TRUE, true, "1", null)).isFalse();
+    assertThat(TelemetryReporter.isEnabled("production", Boolean.FALSE, true, null)).isFalse();
   }
 
   @Test
   @DisplayName("AXONFLOW_TELEMETRY=off takes precedence over config override")
   void testAxonflowTelemetryPrecedence() {
-    assertThat(TelemetryReporter.isEnabled("production", Boolean.TRUE, true, null, "off"))
-        .isFalse();
+    assertThat(TelemetryReporter.isEnabled("production", Boolean.TRUE, true, "off")).isFalse();
   }
 
   // --- Payload format test ---
@@ -151,7 +136,6 @@ class TelemetryReporterTest {
         Boolean.TRUE,
         false,
         true, // hasCredentials
-        null, // doNotTrack
         null, // axonflowTelemetry
         customUrl // checkpointUrl
         );
@@ -175,26 +159,50 @@ class TelemetryReporterTest {
   }
 
   @Test
-  @DisplayName("should not send ping when telemetry is disabled")
+  @DisplayName("should not send ping when telemetry is disabled via AXONFLOW_TELEMETRY=off")
   void testNoRequestWhenDisabled(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
     stubFor(post("/v1/ping").willReturn(ok()));
 
     String customUrl = wmRuntimeInfo.getHttpBaseUrl() + "/v1/ping";
 
-    // Disable via DO_NOT_TRACK
     TelemetryReporter.sendPing(
         "production",
         "http://localhost:8080",
         null,
         false,
         true, // hasCredentials
-        "1", // doNotTrack = disabled
-        null,
+        "off", // axonflowTelemetry = canonical opt-out
         customUrl);
 
     Thread.sleep(1000);
 
     verify(exactly(0), postRequestedFor(urlEqualTo("/v1/ping")));
+  }
+
+  @Test
+  @DisplayName("should STILL send ping when only DO_NOT_TRACK=1 is set in process env (DNT no longer honored)")
+  void testRequestSentEvenWithDoNotTrackInProcessEnv(WireMockRuntimeInfo wmRuntimeInfo)
+      throws Exception {
+    // Note: this test passes axonflowTelemetry=null, which is what the public
+    // sendPing wrapper would supply if DO_NOT_TRACK=1 were the only env signal.
+    // After the DNT removal, the SDK no longer reads DO_NOT_TRACK at all, so a
+    // null axonflowTelemetry means "no opt-out env" and telemetry should fire.
+    stubFor(post("/v1/ping").willReturn(ok()));
+
+    String customUrl = wmRuntimeInfo.getHttpBaseUrl() + "/v1/ping";
+
+    TelemetryReporter.sendPing(
+        "production",
+        "http://localhost:8080",
+        null,
+        false,
+        true, // hasCredentials
+        null, // axonflowTelemetry = not set, telemetry should fire
+        customUrl);
+
+    Thread.sleep(1000);
+
+    verify(exactly(1), postRequestedFor(urlEqualTo("/v1/ping")));
   }
 
   @Test
@@ -209,7 +217,6 @@ class TelemetryReporterTest {
                   null,
                   false,
                   true, // hasCredentials
-                  null,
                   null,
                   "http://127.0.0.1:1" // port 1 - connection refused
                   );
@@ -234,7 +241,6 @@ class TelemetryReporterTest {
         false,
         true, // hasCredentials
         null,
-        null,
         customUrl);
 
     Thread.sleep(1000);
@@ -255,7 +261,6 @@ class TelemetryReporterTest {
         Boolean.TRUE, // explicit enable
         false,
         false, // hasCredentials (doesn't matter with explicit override)
-        null,
         null,
         customUrl);
 
@@ -278,7 +283,6 @@ class TelemetryReporterTest {
         Boolean.TRUE,
         false,
         false, // no credentials — no longer affects default
-        null,
         null,
         customUrl);
 
@@ -329,7 +333,6 @@ class TelemetryReporterTest {
         false,
         true, // hasCredentials (would normally enable)
         null,
-        null,
         customUrl);
 
     Thread.sleep(1000);
@@ -353,7 +356,6 @@ class TelemetryReporterTest {
                   null,
                   false,
                   true, // hasCredentials
-                  null,
                   null,
                   customUrl);
 
@@ -380,7 +382,6 @@ class TelemetryReporterTest {
                   false,
                   true, // hasCredentials
                   null,
-                  null,
                   customUrl);
 
               // Give the async call time to complete
@@ -405,7 +406,6 @@ class TelemetryReporterTest {
         null,
         false,
         true, // hasCredentials
-        null,
         "off", // AXONFLOW_TELEMETRY=off
         customUrl);
 
@@ -430,7 +430,6 @@ class TelemetryReporterTest {
         Boolean.TRUE,
         false,
         true, // hasCredentials
-        null,
         null,
         customUrl);
 


### PR DESCRIPTION
## Summary

**BREAKING:** `DO_NOT_TRACK` is no longer honored as an AxonFlow telemetry opt-out. Use `AXONFLOW_TELEMETRY=off` instead.

`DO_NOT_TRACK` was deprecated because it is commonly inherited from host tools and developer environments (CLIs like Codex and Claude Code inject it unconditionally), which makes it an unreliable expression of user intent for AxonFlow telemetry. Major version bump at release time under explicit approval — not in this PR.

## Changes

- `src/main/java/.../telemetry/TelemetryReporter.java` — drop DNT branch + `logger.warn` deprecation message from `isEnabled`. Reduce package-private `isEnabled` overload from 5 args to 4 (drop `String doNotTrack`); reduce `sendPing` overload from 8 args to 7. Public 5-arg `sendPing` wrapper updated to match.
- `src/main/java/.../AxonFlowConfig.java` — `telemetry()` builder docstring refreshed.
- `src/test/java/.../TelemetryReporterTest.java` — flip every DNT-suppress assertion. Update all `sendPing` test call sites to the new 7-arg signature. Add positive regression "should STILL send ping when only DO_NOT_TRACK=1 is set in process env (DNT no longer honored)".
- `src/test/java/.../TelemetryReporterShortLivedTest.java` — `sendPing` call updated to new 7-arg signature.
- `.github/workflows/{ci,integration,release,wire-shape-contract,validate-version-alignment}.yml` — migrate suppression env.
- `README.md`, `CHANGELOG.md` — updated.

## Test plan

- [x] `mvn test -Dtest=TelemetryReporterTest,TelemetryReporterShortLivedTest` — 24/24 pass
- [x] `mvn test` — full suite exit 0
- [ ] CI green