### PR TITLE
feat(telemetry): 7-day delivered-heartbeat with stamp-on-success

### DIFF
--- a/.github/workflows/heartbeat-real-stack.yml
+++ b/.github/workflows/heartbeat-real-stack.yml
@@ -1,0 +1,68 @@
+name: heartbeat-real-stack
+
+# Real-stack heartbeat E2E across Linux + Windows + macOS. Stands up a
+# localhost fake checkpoint server, constructs the SDK through its
+# public API, verifies (a) the OS-native stamp file appears, (b) the
+# checkpoint endpoint received exactly one ping, (c) a second
+# invocation does NOT re-fire (warm-cache regression).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  AXONFLOW_TELEMETRY: 'off'
+
+jobs:
+  real-stack:
+    name: real-stack ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Set up Python (for harness driver)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build SDK jar
+        run: mvn -B -DskipTests package -Dmaven.javadoc.skip=true
+
+      # Compile smoke + run real-stack E2E in a single shell so the
+      # classpath separator (`:` on Linux/macOS, `;` on Windows) is
+      # native to the shell and consistent across javac + java steps.
+      - name: Compile + run real-stack heartbeat E2E (cold + warm)
+        shell: bash
+        run: |
+          set -e
+          SDK_JAR=$(ls target/axonflow-sdk-*.jar | grep -v sources | head -1)
+          mvn -B dependency:build-classpath -Dmdep.outputFile=cp.txt -Dmdep.includeScope=runtime
+          DEPS=$(cat cp.txt)
+          # bash on Windows runners (Git Bash) handles ':' as the path
+          # separator inside the shell process, but `java` and `javac`
+          # are native Windows binaries that need ';'. Detect and rewrite.
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            CP_SEP=';'
+          else
+            CP_SEP=':'
+          fi
+          mkdir -p tests/heartbeat-real-stack/build
+          javac -d tests/heartbeat-real-stack/build \
+            -cp "${SDK_JAR}${CP_SEP}${DEPS}" \
+            tests/heartbeat-real-stack/SmokeJava.java
+          CP="tests/heartbeat-real-stack/build${CP_SEP}${SDK_JAR}${CP_SEP}${DEPS}"
+          python tests/heartbeat-real-stack/run_real_stack.py java -cp "$CP" SmokeJava

--- a/.github/workflows/heartbeat-real-stack.yml
+++ b/.github/workflows/heartbeat-real-stack.yml
@@ -40,6 +40,11 @@ jobs:
           python-version: '3.11'
 
       - name: Build SDK jar
+        # bash on every OS — PowerShell on Windows mangles -D... arguments,
+        # splitting `-Dmaven.javadoc.skip=true` into ".javadoc.skip=true" as
+        # a phase. The bash shell on Windows runners (Git Bash) handles -D
+        # quoting consistently with Linux/macOS.
+        shell: bash
         run: mvn -B -DskipTests package -Dmaven.javadoc.skip=true
 
       # Compile smoke + run real-stack E2E in a single shell so the

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ local.properties
 
 .codex/
 .claude
+
+# Heartbeat real-stack smoke build dir
+tests/heartbeat-real-stack/build/
+tests/heartbeat-real-stack/cp.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The one-line `DO_NOT_TRACK=1 is deprecated...` `logger.warn` is no longer emitted. Removing the warning eliminates log noise that previously appeared on every telemetry decision when `DO_NOT_TRACK=1` was set.
 
+### Changed
+
+- **Telemetry now follows the 7-day delivered-heartbeat contract** instead of firing on every `new AxonFlow()` construction. The SDK emits at most one anonymous heartbeat per environment every 7 days during SDK activity. A stamp file at the OS-native user cache dir tracks last successful delivery; mtime is the source of truth across process restarts. Failed POSTs do NOT advance the stamp — a transient network error does not silence telemetry for 7 days. An in-memory 1-hour cache caps `Files.getLastModifiedTime` calls on hot request paths; a `ReentrantLock`-guarded in-flight flag coalesces concurrent threads so only one ping fires under load. `AXONFLOW_TELEMETRY=off` is re-evaluated on every gate run. Restricted environments where no cache dir is available (e.g. AWS Lambda with no `HOME`/`LOCALAPPDATA`) fall back transparently to the previous "one ping per construction" behavior.
+
 ### CI / development
 
 - CI workflows (`ci.yml`, `integration.yml`, `release.yml`, `wire-shape-contract.yml`, `validate-version-alignment.yml`) now use `AXONFLOW_TELEMETRY=off` to suppress telemetry during automated runs.

--- a/src/main/java/com/getaxonflow/sdk/AxonFlow.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlow.java
@@ -125,14 +125,12 @@ public final class AxonFlow implements Closeable {
 
   private final AxonFlowConfig config;
   private final OkHttpClient httpClient;
-  /**
-   * Telemetry heartbeat gate — at most one anonymous ping per machine per
-   * 7 days during SDK activity. Consulted from the constructor and from
-   * {@link #executeHttp(OkHttpClient, Request)} on every public API call.
-   * See {@link HeartbeatState} for the algorithm and stamp-on-DELIVERY
-   * semantics.
-   */
-  private final HeartbeatState heartbeat = new HeartbeatState();
+
+  // Telemetry heartbeat is process-global — see HeartbeatState.shared().
+  // No instance field here on purpose: concurrent AxonFlow constructions
+  // on the same JVM must coalesce onto a single ping per
+  // heartbeatInterval, which requires a shared singleton, not a per-
+  // instance gate. Access via {@link #invokeHeartbeat()}.
 
   /**
    * Clone of {@link #httpClient} with {@code callTimeout} overridden to {@code
@@ -192,9 +190,20 @@ public final class AxonFlow implements Closeable {
   }
 
   /**
-   * Run the heartbeat gate. Constructs the gating decision from the
-   * client's mode/config, then asks {@link #heartbeat} to decide whether
-   * to send (and to write the stamp on success).
+   * Run the heartbeat gate against the process-global singleton. Constructs
+   * the gating decision from this client's mode/config, then asks
+   * {@link HeartbeatState#shared()} to decide whether to send (and to
+   * write the stamp on success).
+   *
+   * <p>This call is synchronous and bounded by the per-call HTTP timeout
+   * (3s) WHEN the gate decides to fire. When the gate decides not to fire
+   * (typical hot-path case after the first cold-start ping), the cost is
+   * a single mutex acquire and a {@code System.currentTimeMillis()}
+   * comparison.
+   *
+   * <p>For the request hot path, see {@link #invokeHeartbeatAsync()},
+   * which delegates to a daemon thread so a 3-second firing-block never
+   * delays a user API call.
    */
   private void invokeHeartbeat() {
     boolean hasCredentials =
@@ -206,20 +215,42 @@ public final class AxonFlow implements Closeable {
     String envOptOut = System.getenv("AXONFLOW_TELEMETRY");
     boolean isEnabled =
         TelemetryReporter.isEnabled(modeStr, config.getTelemetry(), hasCredentials, envOptOut);
-    heartbeat.maybeSendHeartbeat(
-        isEnabled,
-        () -> TelemetryReporter.sendPingNow(
-            modeStr,
-            config.getEndpoint(),
-            config.isDebug(),
-            System.getenv("AXONFLOW_CHECKPOINT_URL")));
+    // Two-arg public overload reads AXONFLOW_TELEMETRY=off itself via
+    // System.getenv. Tests that bypass this method use the package-private
+    // 3-arg overload to inject the env value directly.
+    HeartbeatState.shared()
+        .maybeSendHeartbeat(
+            isEnabled,
+            () ->
+                TelemetryReporter.sendPingNow(
+                    modeStr,
+                    config.getEndpoint(),
+                    config.isDebug(),
+                    System.getenv("AXONFLOW_CHECKPOINT_URL")));
+  }
+
+  /**
+   * Async variant of {@link #invokeHeartbeat()} — runs the gate in a
+   * short-lived daemon thread so a user-facing API call is never delayed
+   * by the 3-second telemetry POST when the gate decides to fire.
+   *
+   * <p>Daemon thread choice: long-running services have stable JVMs so
+   * the daemon thread completes the POST normally. Short-lived processes
+   * (Lambda cold start, CLI binaries) deliver the boot ping via the
+   * synchronous {@code invokeHeartbeat} call from the constructor, so the
+   * async request-path heartbeat is "extra" — its loss to JVM exit is
+   * acceptable and only matters across the 7-day boundary.
+   */
+  private void invokeHeartbeatAsync() {
+    Thread t = new Thread(this::invokeHeartbeat, "axonflow-heartbeat");
+    t.setDaemon(true);
+    t.start();
   }
 
   /**
    * Single HTTP wrapper used by every public-API request path. Invokes
-   * the heartbeat gate as a side effect (gate enforces its own rate
-   * limit, so this is amortized free on the hot path) and returns the
-   * underlying {@link Response}.
+   * the heartbeat gate as a side effect, ASYNCHRONOUSLY so the user's
+   * API call is never delayed by telemetry.
    *
    * <p>IMPORTANT: This wrapper must NOT be called from telemetry code
    * itself ({@link TelemetryReporter#sendPingNow} or its private helpers).
@@ -227,7 +258,7 @@ public final class AxonFlow implements Closeable {
    * avoid any recursive heartbeat triggering.
    */
   private Response executeHttp(OkHttpClient client, Request request) throws java.io.IOException {
-    invokeHeartbeat();
+    invokeHeartbeatAsync();
     return client.newCall(request).execute();
   }
 

--- a/src/main/java/com/getaxonflow/sdk/AxonFlow.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlow.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.getaxonflow.sdk.exceptions.*;
 import com.getaxonflow.sdk.masfeat.MASFEATTypes.*;
 import com.getaxonflow.sdk.simulation.*;
+import com.getaxonflow.sdk.telemetry.HeartbeatState;
 import com.getaxonflow.sdk.telemetry.TelemetryReporter;
 import com.getaxonflow.sdk.types.*;
 import com.getaxonflow.sdk.types.codegovernance.*;
@@ -124,6 +125,14 @@ public final class AxonFlow implements Closeable {
 
   private final AxonFlowConfig config;
   private final OkHttpClient httpClient;
+  /**
+   * Telemetry heartbeat gate — at most one anonymous ping per machine per
+   * 7 days during SDK activity. Consulted from the constructor and from
+   * {@link #executeHttp(OkHttpClient, Request)} on every public API call.
+   * See {@link HeartbeatState} for the algorithm and stamp-on-DELIVERY
+   * semantics.
+   */
+  private final HeartbeatState heartbeat = new HeartbeatState();
 
   /**
    * Clone of {@link #httpClient} with {@code callTimeout} overridden to {@code
@@ -171,18 +180,55 @@ public final class AxonFlow implements Closeable {
 
     logger.info("AxonFlow client initialized for {}", config.getEndpoint());
 
-    // Send telemetry ping (fire-and-forget).
+    // Heartbeat gate — at most one anonymous ping per machine per 7 days,
+    // gated by SDK activity. The constructor runs the gate synchronously
+    // so a fresh install on a short-lived JVM (CLI binaries, AWS Lambda
+    // cold-starts, quickstart scripts) still delivers the first ping
+    // before main() returns. Subsequent gate runs (from executeHttp) are
+    // also synchronous because OkHttpClient is reusable across calls and
+    // the gate's internal in-flight + 1-hour-cache bounds amortize cost.
+    // See HeartbeatState for the full algorithm.
+    invokeHeartbeat();
+  }
+
+  /**
+   * Run the heartbeat gate. Constructs the gating decision from the
+   * client's mode/config, then asks {@link #heartbeat} to decide whether
+   * to send (and to write the stamp on success).
+   */
+  private void invokeHeartbeat() {
     boolean hasCredentials =
         config.getClientId() != null
             && !config.getClientId().isEmpty()
             && config.getClientSecret() != null
             && !config.getClientSecret().isEmpty();
-    TelemetryReporter.sendPing(
-        config.getMode() != null ? config.getMode().getValue() : "production",
-        config.getEndpoint(),
-        config.getTelemetry(),
-        config.isDebug(),
-        hasCredentials);
+    String modeStr = config.getMode() != null ? config.getMode().getValue() : "production";
+    String envOptOut = System.getenv("AXONFLOW_TELEMETRY");
+    boolean isEnabled =
+        TelemetryReporter.isEnabled(modeStr, config.getTelemetry(), hasCredentials, envOptOut);
+    heartbeat.maybeSendHeartbeat(
+        isEnabled,
+        () -> TelemetryReporter.sendPingNow(
+            modeStr,
+            config.getEndpoint(),
+            config.isDebug(),
+            System.getenv("AXONFLOW_CHECKPOINT_URL")));
+  }
+
+  /**
+   * Single HTTP wrapper used by every public-API request path. Invokes
+   * the heartbeat gate as a side effect (gate enforces its own rate
+   * limit, so this is amortized free on the hot path) and returns the
+   * underlying {@link Response}.
+   *
+   * <p>IMPORTANT: This wrapper must NOT be called from telemetry code
+   * itself ({@link TelemetryReporter#sendPingNow} or its private helpers).
+   * Those build their own throw-away {@code OkHttpClient} instances to
+   * avoid any recursive heartbeat triggering.
+   */
+  private Response executeHttp(OkHttpClient client, Request request) throws java.io.IOException {
+    invokeHeartbeat();
+    return client.newCall(request).execute();
   }
 
   private static ObjectMapper createObjectMapper() {
@@ -288,7 +334,7 @@ public final class AxonFlow implements Closeable {
         retryExecutor.execute(
             () -> {
               Request request = buildRequest("GET", "/health", null);
-              try (Response response = httpClient.newCall(request).execute()) {
+              try (Response response = executeHttp(httpClient, request)) {
                 return parseResponse(response, HealthStatus.class);
               }
             },
@@ -361,7 +407,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildOrchestratorRequest("GET", "/health", null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (!response.isSuccessful()) {
               return new HealthStatus("unhealthy", null, null, null, null, null);
             }
@@ -418,7 +464,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildRequest("POST", "/api/policy/pre-check", finalRequest);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             PolicyApprovalResult result = parseResponse(response, PolicyApprovalResult.class);
 
             if (!result.isApproved()) {
@@ -494,7 +540,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildRequest("POST", "/api/audit/llm-call", effectiveOptions);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, AuditResult.class);
           }
         },
@@ -543,7 +589,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           AuditSearchRequest req = request != null ? request : AuditSearchRequest.builder().build();
           Request httpRequest = buildOrchestratorRequest("POST", "/api/v1/audit/search", req);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             JsonNode node = parseResponseNode(response);
 
             // Handle both array and wrapped response formats
@@ -623,7 +669,7 @@ public final class AxonFlow implements Closeable {
                   .replace("+", "%20");
           String path = "/api/v1/decisions/" + encoded + "/explain";
           Request httpRequest = buildOrchestratorRequest("GET", path, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             JsonNode node = parseResponseNode(response);
             return objectMapper.treeToValue(node, DecisionExplanation.class);
           }
@@ -681,7 +727,7 @@ public final class AxonFlow implements Closeable {
                   + opts.getOffset();
 
           Request httpRequest = buildOrchestratorRequest("GET", path, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             JsonNode node = parseResponseNode(response);
 
             // Handle both array and wrapped response formats
@@ -758,7 +804,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("POST", "/api/v1/audit/tool-call", request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, AuditToolCallResponse.class);
           }
         },
@@ -798,7 +844,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("GET", "/api/v1/circuit-breaker/status", null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             JsonNode node = parseResponseNode(response);
             if (node.has("data") && node.get("data").isObject()) {
               return objectMapper.treeToValue(node.get("data"), CircuitBreakerStatusResponse.class);
@@ -844,7 +890,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           String path = "/api/v1/circuit-breaker/history?limit=" + limit;
           Request httpRequest = buildOrchestratorRequest("GET", path, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             JsonNode node = parseResponseNode(response);
             if (node.has("data") && node.get("data").isObject()) {
               return objectMapper.treeToValue(
@@ -895,7 +941,7 @@ public final class AxonFlow implements Closeable {
               "/api/v1/circuit-breaker/config?tenant_id="
                   + java.net.URLEncoder.encode(tenantId, java.nio.charset.StandardCharsets.UTF_8);
           Request httpRequest = buildOrchestratorRequest("GET", path, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             JsonNode node = parseResponseNode(response);
             if (node.has("data") && node.get("data").isObject()) {
               return objectMapper.treeToValue(node.get("data"), CircuitBreakerConfig.class);
@@ -944,7 +990,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("PUT", "/api/v1/circuit-breaker/config", config);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             JsonNode node = parseResponseNode(response);
             if (node.has("data") && node.get("data").isObject()) {
               return objectMapper.treeToValue(
@@ -1004,7 +1050,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("POST", "/api/v1/policies/simulate", request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             JsonNode node = parseResponseNode(response);
             if (node.has("data") && node.get("data").isObject()) {
               return objectMapper.treeToValue(node.get("data"), SimulatePoliciesResponse.class);
@@ -1059,7 +1105,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("POST", "/api/v1/policies/impact-report", request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             JsonNode node = parseResponseNode(response);
             if (node.has("data") && node.get("data").isObject()) {
               return objectMapper.treeToValue(node.get("data"), ImpactReportResponse.class);
@@ -1139,7 +1185,7 @@ public final class AxonFlow implements Closeable {
           }
           Request httpRequest =
               buildOrchestratorRequest("POST", "/api/v1/policies/conflicts", body);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             JsonNode node = parseResponseNode(response);
             if (node.has("data") && node.get("data").isObject()) {
               return objectMapper.treeToValue(node.get("data"), PolicyConflictResponse.class);
@@ -1245,7 +1291,7 @@ public final class AxonFlow implements Closeable {
         retryExecutor.execute(
             () -> {
               Request httpRequest = buildRequest("POST", "/api/request", finalRequest);
-              try (Response httpResponse = httpClient.newCall(httpRequest).execute()) {
+              try (Response httpResponse = executeHttp(httpClient, httpRequest)) {
                 ClientResponse result = parseResponse(httpResponse, ClientResponse.class);
 
                 if (result.isBlocked()) {
@@ -1316,7 +1362,7 @@ public final class AxonFlow implements Closeable {
           agentRequest.put("context", Map.of("domain", domain));
 
           Request httpRequest = buildRequest("POST", "/api/request", agentRequest);
-          try (Response response = planHttpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(planHttpClient, httpRequest)) {
             return parsePlanResponse(response, request.getDomain());
           }
         },
@@ -1431,7 +1477,7 @@ public final class AxonFlow implements Closeable {
       agentRequest.put("context", Map.of("plan_id", planId));
 
       Request httpRequest = buildRequest("POST", "/api/request", agentRequest);
-      try (Response response = planHttpClient.newCall(httpRequest).execute()) {
+      try (Response response = executeHttp(planHttpClient, httpRequest)) {
         return parseExecutePlanResponse(response, planId);
       }
     } catch (AxonFlowException e) {
@@ -1529,7 +1575,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildRequest("GET", "/api/v1/plan/" + planId, null);
-          try (Response response = planHttpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(planHttpClient, httpRequest)) {
             return parseResponse(response, PlanResponse.class);
           }
         },
@@ -1575,7 +1621,7 @@ public final class AxonFlow implements Closeable {
           agentRequest.put("context", context);
 
           Request httpRequest = buildRequest("POST", "/api/request", agentRequest);
-          try (Response response = planHttpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(planHttpClient, httpRequest)) {
             return parsePlanResponse(response, request.getDomain());
           }
         },
@@ -1602,7 +1648,7 @@ public final class AxonFlow implements Closeable {
           Request httpRequest =
               buildRequest(
                   "POST", "/api/v1/plan/" + planId + "/cancel", body.isEmpty() ? null : body);
-          try (Response response = planHttpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(planHttpClient, httpRequest)) {
             return parseResponse(response, CancelPlanResponse.class);
           }
         },
@@ -1638,7 +1684,7 @@ public final class AxonFlow implements Closeable {
       return retryExecutor.execute(
           () -> {
             Request httpRequest = buildRequest("PUT", "/api/v1/plan/" + planId, request);
-            try (Response response = planHttpClient.newCall(httpRequest).execute()) {
+            try (Response response = executeHttp(planHttpClient, httpRequest)) {
               return parseResponse(response, UpdatePlanResponse.class);
             }
           },
@@ -1663,7 +1709,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildRequest("GET", "/api/v1/plan/" + planId + "/versions", null);
-          try (Response response = planHttpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(planHttpClient, httpRequest)) {
             return parseResponse(response, PlanVersionsResponse.class);
           }
         },
@@ -1686,7 +1732,7 @@ public final class AxonFlow implements Closeable {
           body.put("approved", approved != null ? approved : true);
 
           Request httpRequest = buildRequest("POST", "/api/v1/plan/" + planId + "/resume", body);
-          try (Response response = planHttpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(planHttpClient, httpRequest)) {
             return parseResponse(response, ResumePlanResponse.class);
           }
         },
@@ -1720,7 +1766,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildRequest("POST", "/api/v1/plan/" + planId + "/rollback/" + targetVersion, null);
-          try (Response response = planHttpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(planHttpClient, httpRequest)) {
             return parseResponse(response, RollbackPlanResponse.class);
           }
         },
@@ -1813,7 +1859,7 @@ public final class AxonFlow implements Closeable {
           Request.Builder reqBuilder = new Request.Builder().url(url).get();
           addAuthHeaders(reqBuilder);
           Request httpRequest = reqBuilder.build();
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             JsonNode node = parseResponseNode(response);
             // The platform always wraps in {providers, pagination}, but tolerate
             // bare arrays from older builds via a synthetic single-page meta.
@@ -1879,7 +1925,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildOrchestratorRequest("GET", "/api/v1/connectors", null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             // Response is wrapped: {"connectors": [...], "total": N}
             JsonNode node = parseResponseNode(response);
             if (node.has("connectors")) {
@@ -1916,7 +1962,7 @@ public final class AxonFlow implements Closeable {
           Map<String, Object> body = Map.of("config", config != null ? config : Map.of());
           String path = "/api/v1/connectors/" + connectorId + "/install";
           Request httpRequest = buildOrchestratorRequest("POST", path, body);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, ConnectorInfo.class);
           }
         },
@@ -1935,7 +1981,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           String path = "/api/v1/connectors/" + connectorName;
           Request httpRequest = buildOrchestratorRequest("DELETE", path, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (!response.isSuccessful() && response.code() != 204) {
               handleErrorResponse(response);
             }
@@ -1958,7 +2004,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           String path = "/api/v1/connectors/" + connectorId;
           Request httpRequest = buildOrchestratorRequest("GET", path, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, ConnectorInfo.class);
           }
         },
@@ -1988,7 +2034,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           String path = "/api/v1/connectors/" + connectorId + "/health";
           Request httpRequest = buildOrchestratorRequest("GET", path, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, ConnectorHealthStatus.class);
           }
         },
@@ -2040,7 +2086,7 @@ public final class AxonFlow implements Closeable {
                   .build();
 
           Request httpRequest = buildRequest("POST", "/api/request", clientRequest);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             ClientResponse clientResponse = parseResponse(response, ClientResponse.class);
 
             // Convert ClientResponse to ConnectorResponse
@@ -2132,7 +2178,7 @@ public final class AxonFlow implements Closeable {
           }
 
           Request httpRequest = buildRequest("POST", "/mcp/resources/query", body);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             // Parse the response body
             ResponseBody responseBody = response.body();
             if (responseBody == null) {
@@ -2257,7 +2303,7 @@ public final class AxonFlow implements Closeable {
           }
 
           Request httpRequest = buildRequest("POST", "/api/v1/mcp/check-input", request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             ResponseBody responseBody = response.body();
             if (responseBody == null) {
               throw new ConnectorException(
@@ -2373,7 +2419,7 @@ public final class AxonFlow implements Closeable {
               new MCPCheckOutputRequest(connectorType, responseData, message, metadata, rowCount);
 
           Request httpRequest = buildRequest("POST", "/api/v1/mcp/check-output", request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             ResponseBody responseBody = response.body();
             if (responseBody == null) {
               throw new ConnectorException(
@@ -2566,7 +2612,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           String path = buildPolicyQueryString("/api/v1/static-policies", options);
           Request httpRequest = buildRequest("GET", path, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             StaticPoliciesResponse wrapper = parseResponse(response, StaticPoliciesResponse.class);
             // Handle null wrapper or null policies list (Issue #40)
             if (wrapper == null || wrapper.getPolicies() == null) {
@@ -2624,7 +2670,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildRequest("GET", "/api/v1/static-policies/" + policyId, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, StaticPolicy.class);
           }
         },
@@ -2643,7 +2689,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildRequest("POST", "/api/v1/static-policies", request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, StaticPolicy.class);
           }
         },
@@ -2664,7 +2710,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildRequest("PUT", "/api/v1/static-policies/" + policyId, request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, StaticPolicy.class);
           }
         },
@@ -2682,7 +2728,7 @@ public final class AxonFlow implements Closeable {
     retryExecutor.execute(
         () -> {
           Request httpRequest = buildRequest("DELETE", "/api/v1/static-policies/" + policyId, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (!response.isSuccessful() && response.code() != 204) {
               handleErrorResponse(response);
             }
@@ -2706,7 +2752,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Map<String, Object> body = Map.of("enabled", enabled);
           Request httpRequest = buildPatchRequest("/api/v1/static-policies/" + policyId, body);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, StaticPolicy.class);
           }
         },
@@ -2750,7 +2796,7 @@ public final class AxonFlow implements Closeable {
             }
           }
           Request httpRequest = buildRequest("GET", path.toString(), null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             EffectivePoliciesResponse wrapper =
                 parseResponse(response, EffectivePoliciesResponse.class);
             // Handle null wrapper or null policies list (Issue #40)
@@ -2781,7 +2827,7 @@ public final class AxonFlow implements Closeable {
                   "pattern", pattern,
                   "inputs", testInputs);
           Request httpRequest = buildRequest("POST", "/api/v1/static-policies/test", body);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, TestPatternResult.class);
           }
         },
@@ -2801,7 +2847,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildRequest("GET", "/api/v1/static-policies/" + policyId + "/versions", null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             Map<String, Object> wrapper =
                 parseResponse(response, new TypeReference<Map<String, Object>>() {});
             @SuppressWarnings("unchecked")
@@ -2840,7 +2886,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildRequest("POST", "/api/v1/static-policies/" + policyId + "/override", request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, PolicyOverride.class);
           }
         },
@@ -2859,7 +2905,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildRequest("DELETE", "/api/v1/static-policies/" + policyId + "/override", null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (!response.isSuccessful() && response.code() != 204) {
               handleErrorResponse(response);
             }
@@ -2878,7 +2924,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildRequest("GET", "/api/v1/static-policies/overrides", null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             // Backend returns wrapped response: {"overrides": [...], "count": N}
             Map<String, Object> wrapper =
                 parseResponse(response, new TypeReference<Map<String, Object>>() {});
@@ -2920,7 +2966,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           String path = buildDynamicPolicyQueryString("/api/v1/dynamic-policies", options);
           Request httpRequest = buildOrchestratorRequest("GET", path, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             // Agent proxy (Issue #886) returns {"policies": [...]} wrapper
             DynamicPoliciesResponse wrapper =
                 parseResponse(response, DynamicPoliciesResponse.class);
@@ -2947,7 +2993,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("GET", "/api/v1/dynamic-policies/" + policyId, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             // Agent proxy (Issue #886) returns {"policy": {...}} wrapper
             DynamicPolicyResponse wrapper = parseResponse(response, DynamicPolicyResponse.class);
             return wrapper != null ? wrapper.getPolicy() : null;
@@ -2969,7 +3015,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("POST", "/api/v1/dynamic-policies", request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             // Agent proxy (Issue #886) returns {"policy": {...}} wrapper
             DynamicPolicyResponse wrapper = parseResponse(response, DynamicPolicyResponse.class);
             return wrapper != null ? wrapper.getPolicy() : null;
@@ -2993,7 +3039,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("PUT", "/api/v1/dynamic-policies/" + policyId, request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             // Agent proxy (Issue #886) returns {"policy": {...}} wrapper
             DynamicPolicyResponse wrapper = parseResponse(response, DynamicPolicyResponse.class);
             return wrapper != null ? wrapper.getPolicy() : null;
@@ -3014,7 +3060,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("DELETE", "/api/v1/dynamic-policies/" + policyId, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (!response.isSuccessful() && response.code() != 204) {
               handleErrorResponse(response);
             }
@@ -3039,7 +3085,7 @@ public final class AxonFlow implements Closeable {
           Map<String, Object> body = Map.of("enabled", enabled);
           Request httpRequest =
               buildOrchestratorRequest("PUT", "/api/v1/dynamic-policies/" + policyId, body);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             // Agent proxy (Issue #886) returns {"policy": {...}} wrapper
             DynamicPolicyResponse wrapper = parseResponse(response, DynamicPolicyResponse.class);
             return wrapper != null ? wrapper.getPolicy() : null;
@@ -3074,7 +3120,7 @@ public final class AxonFlow implements Closeable {
             }
           }
           Request httpRequest = buildOrchestratorRequest("GET", path.toString(), null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             // Agent proxy (Issue #886) returns {"policies": [...]} wrapper
             DynamicPoliciesResponse wrapper =
                 parseResponse(response, DynamicPoliciesResponse.class);
@@ -3109,7 +3155,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("GET", "/api/v1/unified/executions/" + executionId, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(
                 response, com.getaxonflow.sdk.types.execution.ExecutionTypes.ExecutionStatus.class);
           }
@@ -3160,7 +3206,7 @@ public final class AxonFlow implements Closeable {
             }
           }
           Request httpRequest = buildOrchestratorRequest("GET", path.toString(), null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(
                 response,
                 com.getaxonflow.sdk.types.execution.ExecutionTypes.UnifiedListExecutionsResponse
@@ -3189,7 +3235,7 @@ public final class AxonFlow implements Closeable {
           Request httpRequest =
               buildOrchestratorRequest(
                   "POST", "/api/v1/unified/executions/" + executionId + "/cancel", body);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (!response.isSuccessful()) {
               handleErrorResponse(response);
             }
@@ -3265,7 +3311,7 @@ public final class AxonFlow implements Closeable {
     Request httpRequest = builder.build();
 
     try {
-      Response response = httpClient.newCall(httpRequest).execute();
+      Response response = executeHttp(httpClient, httpRequest);
       try {
         if (!response.isSuccessful()) {
           handleErrorResponse(response);
@@ -3345,7 +3391,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildRequest("GET", "/api/v1/media-governance/config", null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, MediaGovernanceConfig.class);
           }
         },
@@ -3377,7 +3423,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildRequest("PUT", "/api/v1/media-governance/config", request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, MediaGovernanceConfig.class);
           }
         },
@@ -3408,7 +3454,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildRequest("GET", "/api/v1/media-governance/status", null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, MediaGovernanceStatus.class);
           }
         },
@@ -3830,7 +3876,7 @@ public final class AxonFlow implements Closeable {
             .header("Content-Type", "application/json")
             .build();
 
-    try (Response response = httpClient.newCall(request).execute()) {
+    try (Response response = executeHttp(httpClient, request)) {
       if (!response.isSuccessful()) {
         throw new AuthenticationException("Login failed: " + response.body().string());
       }
@@ -3871,7 +3917,7 @@ public final class AxonFlow implements Closeable {
               .header("Cookie", "axonflow_session=" + sessionCookie)
               .build();
 
-      httpClient.newCall(request).execute().close();
+      executeHttp(httpClient, request).close();
     } catch (Exception e) {
       // Ignore logout errors
     }
@@ -3916,7 +3962,7 @@ public final class AxonFlow implements Closeable {
 
     addPortalSessionCookie(builder);
 
-    try (Response response = httpClient.newCall(builder.build()).execute()) {
+    try (Response response = executeHttp(httpClient, builder.build())) {
       return parseResponse(response, ValidateGitProviderResponse.class);
     }
   }
@@ -3943,7 +3989,7 @@ public final class AxonFlow implements Closeable {
 
     addPortalSessionCookie(builder);
 
-    try (Response response = httpClient.newCall(builder.build()).execute()) {
+    try (Response response = executeHttp(httpClient, builder.build())) {
       return parseResponse(response, ConfigureGitProviderResponse.class);
     }
   }
@@ -3965,7 +4011,7 @@ public final class AxonFlow implements Closeable {
 
     addPortalSessionCookie(builder);
 
-    try (Response response = httpClient.newCall(builder.build()).execute()) {
+    try (Response response = executeHttp(httpClient, builder.build())) {
       return parseResponse(response, ListGitProvidersResponse.class);
     }
   }
@@ -3990,7 +4036,7 @@ public final class AxonFlow implements Closeable {
 
     addPortalSessionCookie(builder);
 
-    try (Response response = httpClient.newCall(builder.build()).execute()) {
+    try (Response response = executeHttp(httpClient, builder.build())) {
       handleErrorResponse(response);
     }
   }
@@ -4015,7 +4061,7 @@ public final class AxonFlow implements Closeable {
 
     addPortalSessionCookie(builder);
 
-    try (Response response = httpClient.newCall(builder.build()).execute()) {
+    try (Response response = executeHttp(httpClient, builder.build())) {
       return parseResponse(response, CreatePRResponse.class);
     }
   }
@@ -4054,7 +4100,7 @@ public final class AxonFlow implements Closeable {
 
     addPortalSessionCookie(builder);
 
-    try (Response response = httpClient.newCall(builder.build()).execute()) {
+    try (Response response = executeHttp(httpClient, builder.build())) {
       return parseResponse(response, ListPRsResponse.class);
     }
   }
@@ -4087,7 +4133,7 @@ public final class AxonFlow implements Closeable {
 
     addPortalSessionCookie(builder);
 
-    try (Response response = httpClient.newCall(builder.build()).execute()) {
+    try (Response response = executeHttp(httpClient, builder.build())) {
       return parseResponse(response, PRRecord.class);
     }
   }
@@ -4112,7 +4158,7 @@ public final class AxonFlow implements Closeable {
 
     addPortalSessionCookie(builder);
 
-    try (Response response = httpClient.newCall(builder.build()).execute()) {
+    try (Response response = executeHttp(httpClient, builder.build())) {
       return parseResponse(response, PRRecord.class);
     }
   }
@@ -4139,7 +4185,7 @@ public final class AxonFlow implements Closeable {
 
     addPortalSessionCookie(builder);
 
-    try (Response response = httpClient.newCall(builder.build()).execute()) {
+    try (Response response = executeHttp(httpClient, builder.build())) {
       return parseResponse(response, PRRecord.class);
     }
   }
@@ -4159,7 +4205,7 @@ public final class AxonFlow implements Closeable {
 
     addPortalSessionCookie(builder);
 
-    try (Response response = httpClient.newCall(builder.build()).execute()) {
+    try (Response response = executeHttp(httpClient, builder.build())) {
       return parseResponse(response, CodeGovernanceMetrics.class);
     }
   }
@@ -4201,7 +4247,7 @@ public final class AxonFlow implements Closeable {
 
     addPortalSessionCookie(builder);
 
-    try (Response response = httpClient.newCall(builder.build()).execute()) {
+    try (Response response = executeHttp(httpClient, builder.build())) {
       return parseResponse(response, ExportResponse.class);
     }
   }
@@ -4239,7 +4285,7 @@ public final class AxonFlow implements Closeable {
 
     addPortalSessionCookie(builder);
 
-    try (Response response = httpClient.newCall(builder.build()).execute()) {
+    try (Response response = executeHttp(httpClient, builder.build())) {
       handleErrorResponse(response);
       ResponseBody body = response.body();
       if (body == null) {
@@ -4418,7 +4464,7 @@ public final class AxonFlow implements Closeable {
           }
 
           Request httpRequest = buildOrchestratorRequest("GET", path.toString(), null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, ListExecutionsResponse.class);
           }
         },
@@ -4455,7 +4501,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("GET", "/api/v1/executions/" + executionId, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, ExecutionDetail.class);
           }
         },
@@ -4475,7 +4521,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("GET", "/api/v1/executions/" + executionId + "/steps", null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, new TypeReference<List<ExecutionSnapshot>>() {});
           }
         },
@@ -4496,7 +4542,7 @@ public final class AxonFlow implements Closeable {
           Request httpRequest =
               buildOrchestratorRequest(
                   "GET", "/api/v1/executions/" + executionId + "/timeline", null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, new TypeReference<List<TimelineEntry>>() {});
           }
         },
@@ -4546,7 +4592,7 @@ public final class AxonFlow implements Closeable {
           }
 
           Request httpRequest = buildOrchestratorRequest("GET", path.toString(), null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, new TypeReference<Map<String, Object>>() {});
           }
         },
@@ -4575,7 +4621,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("DELETE", "/api/v1/executions/" + executionId, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (!response.isSuccessful() && response.code() != 204) {
               handleErrorResponse(response);
             }
@@ -4622,7 +4668,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildOrchestratorRequest("POST", "/api/v1/budgets", request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, Budget.class);
           }
         },
@@ -4642,7 +4688,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("GET", "/api/v1/budgets/" + budgetId, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, Budget.class);
           }
         },
@@ -4678,7 +4724,7 @@ public final class AxonFlow implements Closeable {
           }
 
           Request httpRequest = buildOrchestratorRequest("GET", path.toString(), null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, BudgetsResponse.class);
           }
         },
@@ -4709,7 +4755,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("PUT", "/api/v1/budgets/" + budgetId, request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, Budget.class);
           }
         },
@@ -4728,7 +4774,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("DELETE", "/api/v1/budgets/" + budgetId, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (!response.isSuccessful() && response.code() != 204) {
               handleErrorResponse(response);
             }
@@ -4755,7 +4801,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("GET", "/api/v1/budgets/" + budgetId + "/status", null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, BudgetStatus.class);
           }
         },
@@ -4775,7 +4821,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("GET", "/api/v1/budgets/" + budgetId + "/alerts", null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, BudgetAlertsResponse.class);
           }
         },
@@ -4794,7 +4840,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildOrchestratorRequest("POST", "/api/v1/budgets/check", request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, BudgetDecision.class);
           }
         },
@@ -4820,7 +4866,7 @@ public final class AxonFlow implements Closeable {
           }
 
           Request httpRequest = buildOrchestratorRequest("GET", path.toString(), null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, UsageSummary.class);
           }
         },
@@ -4861,7 +4907,7 @@ public final class AxonFlow implements Closeable {
           }
 
           Request httpRequest = buildOrchestratorRequest("GET", path.toString(), null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, UsageBreakdown.class);
           }
         },
@@ -4900,7 +4946,7 @@ public final class AxonFlow implements Closeable {
           }
 
           Request httpRequest = buildOrchestratorRequest("GET", path.toString(), null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, UsageRecordsResponse.class);
           }
         },
@@ -4945,7 +4991,7 @@ public final class AxonFlow implements Closeable {
           }
 
           Request httpRequest = buildOrchestratorRequest("GET", path.toString(), null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             String body = response.body() != null ? response.body().string() : "";
             if (!response.isSuccessful()) {
               throw new AxonFlowException("Failed to get pricing: " + body);
@@ -5064,7 +5110,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildOrchestratorRequest("POST", "/api/v1/workflows", request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(
                 response,
                 new TypeReference<
@@ -5089,7 +5135,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("GET", "/api/v1/workflows/" + workflowId, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(
                 response,
                 new TypeReference<
@@ -5180,7 +5226,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildOrchestratorRequest("POST", fullPath, request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (response.code() == 409) {
               throw toIdempotencyOrGeneric409(response, workflowId, stepId);
             }
@@ -5216,7 +5262,7 @@ public final class AxonFlow implements Closeable {
                   "POST",
                   "/api/v1/workflows/" + workflowId + "/steps/" + stepId + "/complete",
                   request != null ? request : Collections.emptyMap());
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (response.code() == 409) {
               throw toIdempotencyOrGeneric409(response, workflowId, stepId);
             }
@@ -5287,7 +5333,7 @@ public final class AxonFlow implements Closeable {
           Request httpRequest =
               buildOrchestratorRequest(
                   "POST", "/api/v1/workflows/" + workflowId + "/complete", Collections.emptyMap());
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (!response.isSuccessful()) {
               handleErrorResponse(response);
             }
@@ -5314,7 +5360,7 @@ public final class AxonFlow implements Closeable {
               reason != null ? Collections.singletonMap("reason", reason) : Collections.emptyMap();
           Request httpRequest =
               buildOrchestratorRequest("POST", "/api/v1/workflows/" + workflowId + "/abort", body);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (!response.isSuccessful()) {
               handleErrorResponse(response);
             }
@@ -5351,7 +5397,7 @@ public final class AxonFlow implements Closeable {
               reason != null ? Collections.singletonMap("reason", reason) : Collections.emptyMap();
           Request httpRequest =
               buildOrchestratorRequest("POST", "/api/v1/workflows/" + workflowId + "/fail", body);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (!response.isSuccessful()) {
               handleErrorResponse(response);
             }
@@ -5401,7 +5447,7 @@ public final class AxonFlow implements Closeable {
           Request httpRequest =
               buildOrchestratorRequest(
                   "POST", "/api/v1/workflows/" + workflowId + "/resume", Collections.emptyMap());
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (!response.isSuccessful()) {
               handleErrorResponse(response);
             }
@@ -5424,7 +5470,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("GET", "/api/v1/workflows/" + workflowId + "/checkpoints", null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(
                 response,
                 new TypeReference<
@@ -5447,7 +5493,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("POST", "/api/v1/workflows/" + workflowId + "/checkpoints/resume", "{}");
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(
                 response,
                 new TypeReference<
@@ -5474,7 +5520,7 @@ public final class AxonFlow implements Closeable {
                   "POST",
                   "/api/v1/workflows/" + workflowId + "/checkpoints/" + checkpointId + "/resume",
                   "{}");
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(
                 response,
                 new TypeReference<
@@ -5520,7 +5566,7 @@ public final class AxonFlow implements Closeable {
           }
 
           Request httpRequest = buildOrchestratorRequest("GET", path.toString(), null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(
                 response,
                 new TypeReference<
@@ -5617,7 +5663,7 @@ public final class AxonFlow implements Closeable {
                   "POST",
                   "/api/v1/workflows/" + workflowId + "/steps/" + stepId + "/approve",
                   body);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(
                 response,
                 new TypeReference<
@@ -5697,7 +5743,7 @@ public final class AxonFlow implements Closeable {
                   "POST",
                   "/api/v1/workflows/" + workflowId + "/steps/" + stepId + "/reject",
                   body);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(
                 response,
                 new TypeReference<
@@ -5750,7 +5796,7 @@ public final class AxonFlow implements Closeable {
           }
 
           Request httpRequest = buildOrchestratorRequest("GET", path.toString(), null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(
                 response,
                 new TypeReference<
@@ -5794,7 +5840,7 @@ public final class AxonFlow implements Closeable {
           }
 
           Request httpRequest = buildOrchestratorRequest("GET", path.toString(), null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(
                 response,
                 new TypeReference<
@@ -5882,7 +5928,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildOrchestratorRequest("POST", "/api/v1/webhooks", request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, WebhookSubscription.class);
           }
         },
@@ -5913,7 +5959,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("GET", "/api/v1/webhooks/" + webhookId, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, WebhookSubscription.class);
           }
         },
@@ -5946,7 +5992,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("PUT", "/api/v1/webhooks/" + webhookId, request);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, WebhookSubscription.class);
           }
         },
@@ -5978,7 +6024,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("DELETE", "/api/v1/webhooks/" + webhookId, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (!response.isSuccessful()) {
               handleErrorResponse(response);
             }
@@ -6008,7 +6054,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildOrchestratorRequest("GET", "/api/v1/webhooks", null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             return parseResponse(response, ListWebhooksResponse.class);
           }
         },
@@ -6065,7 +6111,7 @@ public final class AxonFlow implements Closeable {
           }
 
           Request httpRequest = buildOrchestratorRequest("GET", path.toString(), null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             JsonNode node = parseResponseNode(response);
 
             // Server wraps response: {"success": true, "data": [...], "meta": {...}}
@@ -6134,7 +6180,7 @@ public final class AxonFlow implements Closeable {
         () -> {
           Request httpRequest =
               buildOrchestratorRequest("GET", "/api/v1/hitl/queue/" + requestId, null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             JsonNode node = parseResponseNode(response);
 
             // Server wraps response: {"success": true, "data": {...}}
@@ -6175,7 +6221,7 @@ public final class AxonFlow implements Closeable {
           Request httpRequest =
               buildOrchestratorRequest(
                   "POST", "/api/v1/hitl/queue/" + requestId + "/approve", review);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (!response.isSuccessful()) {
               handleErrorResponse(response);
             }
@@ -6214,7 +6260,7 @@ public final class AxonFlow implements Closeable {
           Request httpRequest =
               buildOrchestratorRequest(
                   "POST", "/api/v1/hitl/queue/" + requestId + "/reject", review);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             if (!response.isSuccessful()) {
               handleErrorResponse(response);
             }
@@ -6250,7 +6296,7 @@ public final class AxonFlow implements Closeable {
     return retryExecutor.execute(
         () -> {
           Request httpRequest = buildOrchestratorRequest("GET", "/api/v1/hitl/stats", null);
-          try (Response response = httpClient.newCall(httpRequest).execute()) {
+          try (Response response = executeHttp(httpClient, httpRequest)) {
             JsonNode node = parseResponseNode(response);
 
             // Server wraps response: {"success": true, "data": {...}}
@@ -6327,7 +6373,7 @@ public final class AxonFlow implements Closeable {
             }
 
             Request httpRequest = buildOrchestratorRequest("POST", BASE_PATH + "/registry", body);
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            try (Response response = executeHttp(httpClient, httpRequest)) {
               return parseSystemResponse(response);
             }
           },
@@ -6350,7 +6396,7 @@ public final class AxonFlow implements Closeable {
 
             Request httpRequest =
                 buildOrchestratorRequest("PUT", BASE_PATH + "/registry/" + systemId, body);
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            try (Response response = executeHttp(httpClient, httpRequest)) {
               return parseSystemResponse(response);
             }
           },
@@ -6370,7 +6416,7 @@ public final class AxonFlow implements Closeable {
           () -> {
             Request httpRequest =
                 buildOrchestratorRequest("GET", BASE_PATH + "/registry/" + systemId, null);
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            try (Response response = executeHttp(httpClient, httpRequest)) {
               return parseSystemResponse(response);
             }
           },
@@ -6387,7 +6433,7 @@ public final class AxonFlow implements Closeable {
           () -> {
             Request httpRequest =
                 buildOrchestratorRequest("GET", BASE_PATH + "/registry/summary", null);
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            try (Response response = executeHttp(httpClient, httpRequest)) {
               return parseSummaryResponse(response);
             }
           },
@@ -6414,7 +6460,7 @@ public final class AxonFlow implements Closeable {
 
             Request httpRequest =
                 buildOrchestratorRequest("POST", BASE_PATH + "/assessments", body);
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            try (Response response = executeHttp(httpClient, httpRequest)) {
               return parseAssessmentResponse(response);
             }
           },
@@ -6434,7 +6480,7 @@ public final class AxonFlow implements Closeable {
           () -> {
             Request httpRequest =
                 buildOrchestratorRequest("GET", BASE_PATH + "/assessments/" + assessmentId, null);
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            try (Response response = executeHttp(httpClient, httpRequest)) {
               return parseAssessmentResponse(response);
             }
           },
@@ -6491,7 +6537,7 @@ public final class AxonFlow implements Closeable {
 
             Request httpRequest =
                 buildOrchestratorRequest("PUT", BASE_PATH + "/assessments/" + assessmentId, body);
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            try (Response response = executeHttp(httpClient, httpRequest)) {
               return parseAssessmentResponse(response);
             }
           },
@@ -6512,7 +6558,7 @@ public final class AxonFlow implements Closeable {
             Request httpRequest =
                 buildOrchestratorRequest(
                     "POST", BASE_PATH + "/assessments/" + assessmentId + "/submit", null);
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            try (Response response = executeHttp(httpClient, httpRequest)) {
               return parseAssessmentResponse(response);
             }
           },
@@ -6541,7 +6587,7 @@ public final class AxonFlow implements Closeable {
             Request httpRequest =
                 buildOrchestratorRequest(
                     "POST", BASE_PATH + "/assessments/" + assessmentId + "/approve", body);
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            try (Response response = executeHttp(httpClient, httpRequest)) {
               return parseAssessmentResponse(response);
             }
           },
@@ -6568,7 +6614,7 @@ public final class AxonFlow implements Closeable {
             Request httpRequest =
                 buildOrchestratorRequest(
                     "POST", BASE_PATH + "/assessments/" + assessmentId + "/reject", body);
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            try (Response response = executeHttp(httpClient, httpRequest)) {
               return parseAssessmentResponse(response);
             }
           },
@@ -6588,7 +6634,7 @@ public final class AxonFlow implements Closeable {
           () -> {
             Request httpRequest =
                 buildOrchestratorRequest("GET", BASE_PATH + "/killswitch/" + systemId, null);
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            try (Response response = executeHttp(httpClient, httpRequest)) {
               return parseKillSwitchResponse(response);
             }
           },
@@ -6626,7 +6672,7 @@ public final class AxonFlow implements Closeable {
             Request httpRequest =
                 buildOrchestratorRequest(
                     "POST", BASE_PATH + "/killswitch/" + systemId + "/configure", body);
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            try (Response response = executeHttp(httpClient, httpRequest)) {
               return parseKillSwitchResponse(response);
             }
           },
@@ -6655,7 +6701,7 @@ public final class AxonFlow implements Closeable {
             Request httpRequest =
                 buildOrchestratorRequest(
                     "POST", BASE_PATH + "/killswitch/" + systemId + "/trigger", body);
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            try (Response response = executeHttp(httpClient, httpRequest)) {
               return parseKillSwitchResponse(response);
             }
           },
@@ -6684,7 +6730,7 @@ public final class AxonFlow implements Closeable {
             Request httpRequest =
                 buildOrchestratorRequest(
                     "POST", BASE_PATH + "/killswitch/" + systemId + "/restore", body);
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            try (Response response = executeHttp(httpClient, httpRequest)) {
               return parseKillSwitchResponse(response);
             }
           },
@@ -6709,7 +6755,7 @@ public final class AxonFlow implements Closeable {
             }
 
             Request httpRequest = buildOrchestratorRequest("GET", path, null);
-            try (Response response = httpClient.newCall(httpRequest).execute()) {
+            try (Response response = executeHttp(httpClient, httpRequest)) {
               return parseKillSwitchHistoryResponse(response);
             }
           },

--- a/src/main/java/com/getaxonflow/sdk/AxonFlow.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlow.java
@@ -49,7 +49,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import okhttp3.*;
 import org.slf4j.Logger;
@@ -123,6 +127,23 @@ public final class AxonFlow implements Closeable {
   private static final Logger logger = LoggerFactory.getLogger(AxonFlow.class);
   private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
 
+  // Single-threaded daemon executor for async heartbeat dispatch from the
+  // request hot path. Bounded to one worker so concurrent gate calls land
+  // serially on the gate's mutex (the gate itself coalesces them via
+  // in-flight + 1-hour cache). Daemon thread never blocks JVM exit.
+  // Static so 10k req/s creates 0 extra threads — the alternative
+  // (`new Thread()` per request) costs ~1ms per spawn at scale.
+  private static final ExecutorService HEARTBEAT_EXECUTOR =
+      Executors.newSingleThreadExecutor(
+          new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+              Thread t = new Thread(r, "axonflow-heartbeat");
+              t.setDaemon(true);
+              return t;
+            }
+          });
+
   private final AxonFlowConfig config;
   private final OkHttpClient httpClient;
 
@@ -183,8 +204,8 @@ public final class AxonFlow implements Closeable {
     // so a fresh install on a short-lived JVM (CLI binaries, AWS Lambda
     // cold-starts, quickstart scripts) still delivers the first ping
     // before main() returns. Subsequent gate runs (from executeHttp) are
-    // also synchronous because OkHttpClient is reusable across calls and
-    // the gate's internal in-flight + 1-hour-cache bounds amortize cost.
+    // dispatched ASYNCHRONOUSLY through a shared single-threaded daemon
+    // executor so a 3-second telemetry POST never delays a user request.
     // See HeartbeatState for the full algorithm.
     invokeHeartbeat();
   }
@@ -230,21 +251,31 @@ public final class AxonFlow implements Closeable {
   }
 
   /**
-   * Async variant of {@link #invokeHeartbeat()} — runs the gate in a
-   * short-lived daemon thread so a user-facing API call is never delayed
-   * by the 3-second telemetry POST when the gate decides to fire.
+   * Async variant of {@link #invokeHeartbeat()} — dispatches the gate
+   * onto {@link #HEARTBEAT_EXECUTOR} so a user-facing API call is never
+   * delayed by the 3-second telemetry POST when the gate decides to fire.
+   *
+   * <p>The executor is a single-threaded daemon — concurrent dispatches
+   * queue rather than spawning threads (10k req/s would otherwise create
+   * 10k threads/s pre-fix). The gate's in-flight + 1-hour cache means
+   * queued runs immediately fast-path past the work, so queue depth is
+   * bounded in practice.
    *
    * <p>Daemon thread choice: long-running services have stable JVMs so
-   * the daemon thread completes the POST normally. Short-lived processes
+   * the executor completes the POST normally. Short-lived processes
    * (Lambda cold start, CLI binaries) deliver the boot ping via the
-   * synchronous {@code invokeHeartbeat} call from the constructor, so the
-   * async request-path heartbeat is "extra" — its loss to JVM exit is
-   * acceptable and only matters across the 7-day boundary.
+   * synchronous {@link #invokeHeartbeat} call from the constructor, so
+   * the async request-path heartbeat is "extra" — its loss to JVM exit
+   * is acceptable and only matters across the 7-day boundary.
    */
   private void invokeHeartbeatAsync() {
-    Thread t = new Thread(this::invokeHeartbeat, "axonflow-heartbeat");
-    t.setDaemon(true);
-    t.start();
+    try {
+      HEARTBEAT_EXECUTOR.execute(this::invokeHeartbeat);
+    } catch (RuntimeException e) {
+      // Executor rejected (e.g. shutdown during JVM teardown) — telemetry
+      // is best-effort; the user request continues unaffected.
+      logger.debug("heartbeat dispatch rejected", e);
+    }
   }
 
   /**

--- a/src/main/java/com/getaxonflow/sdk/telemetry/HeartbeatState.java
+++ b/src/main/java/com/getaxonflow/sdk/telemetry/HeartbeatState.java
@@ -256,14 +256,19 @@ public class HeartbeatState {
       ok = false;
     }
 
+    // Stamp write happens OUTSIDE the lock — Files.* syscalls (mkdir +
+    // createTempFile + writeString + move) are blocking, and holding the
+    // lock through them serializes any concurrent gate run on the same
+    // singleton through file IO. Clear inFlight first so other callers
+    // can fast-path through; the stamp write is independent.
     lock.lock();
     try {
       inFlight = false;
-      if (ok) {
-        writeStampAtomic();
-      }
     } finally {
       lock.unlock();
+    }
+    if (ok) {
+      writeStampAtomic();
     }
   }
 
@@ -305,15 +310,19 @@ public class HeartbeatState {
    * Test-only: install a fresh singleton at the given stamp path
    * (or {@code null} for "no persistence"), returning the previous
    * instance so the caller can restore it on cleanup.
+   *
+   * <p>{@code synchronized} on the class so parallel JUnit suites that
+   * both call {@code replaceForTest} cannot race on the swap and lose
+   * one another's restore handle.
    */
-  public static HeartbeatState replaceForTest(Path stampPath) {
+  public static synchronized HeartbeatState replaceForTest(Path stampPath) {
     HeartbeatState previous = SHARED;
     SHARED = new HeartbeatState(stampPath);
     return previous;
   }
 
   /** Test-only: restore a previously-saved singleton. */
-  public static void restoreForTest(HeartbeatState state) {
+  public static synchronized void restoreForTest(HeartbeatState state) {
     SHARED = state;
   }
 }

--- a/src/main/java/com/getaxonflow/sdk/telemetry/HeartbeatState.java
+++ b/src/main/java/com/getaxonflow/sdk/telemetry/HeartbeatState.java
@@ -278,4 +278,42 @@ public class HeartbeatState {
       lock.unlock();
     }
   }
+
+  // ----------------------------------------------------------------
+  // Process-global singleton — concurrent AxonFlow constructions on
+  // the same JVM coalesce onto a single ping per heartbeatInterval.
+  // The singleton must be shared across all AxonFlow instances or the
+  // gate's in-flight + 1-hour cache offer no protection in the
+  // multi-client startup pattern (a deployment that constructs N
+  // clients concurrently before any stamp exists fires N pings
+  // pre-fix; this singleton brings it to 1).
+  //
+  // Volatile read on access; the swap path takes the same lock as
+  // gate operations to keep ordering simple. Production code goes
+  // through {@link #shared()}; tests override via
+  // {@link #replaceForTest} and {@link #restoreForTest}.
+  // ----------------------------------------------------------------
+
+  private static volatile HeartbeatState SHARED = new HeartbeatState();
+
+  /** Returns the process-global heartbeat singleton. */
+  public static HeartbeatState shared() {
+    return SHARED;
+  }
+
+  /**
+   * Test-only: install a fresh singleton at the given stamp path
+   * (or {@code null} for "no persistence"), returning the previous
+   * instance so the caller can restore it on cleanup.
+   */
+  public static HeartbeatState replaceForTest(Path stampPath) {
+    HeartbeatState previous = SHARED;
+    SHARED = new HeartbeatState(stampPath);
+    return previous;
+  }
+
+  /** Test-only: restore a previously-saved singleton. */
+  public static void restoreForTest(HeartbeatState state) {
+    SHARED = state;
+  }
 }

--- a/src/main/java/com/getaxonflow/sdk/telemetry/HeartbeatState.java
+++ b/src/main/java/com/getaxonflow/sdk/telemetry/HeartbeatState.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2026 AxonFlow
+ * Licensed under the Business Source License 1.1.
+ */
+package com.getaxonflow.sdk.telemetry;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.locks.ReentrantLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 7-day delivered-heartbeat state for the AxonFlow Java SDK telemetry gate.
+ *
+ * <p>Implements the cross-SDK contract:
+ *
+ * <pre>
+ *   AxonFlow emits at most one anonymous heartbeat per environment every
+ *   7 days during SDK activity.
+ * </pre>
+ *
+ * <p>The gate is consulted at client construction and at every public HTTP
+ * request site (via the {@code executeHttp} wrapper in {@code AxonFlow}).
+ * Each gate run:
+ *
+ * <ol>
+ *   <li>Re-evaluates {@code AXONFLOW_TELEMETRY=off} cheaply (lock-free) so
+ *       a mid-process opt-out toggle takes effect immediately.
+ *   <li>Checks an in-memory 1-hour cache to bound stamp-file stat
+ *       frequency on hot request paths.
+ *   <li>Reads the stamp file mtime as the source of truth for last
+ *       successful delivery across process restarts.
+ *   <li>Sends the ping and writes the stamp ONLY on success — stamp-on-
+ *       DELIVERY semantics. Failed POSTs leave the stamp unchanged so
+ *       the next call after the 1-hour cache expires retries.
+ *   <li>Coalesces concurrent callers via an in-flight flag so a stampede
+ *       across the boundary fires exactly one POST.
+ * </ol>
+ *
+ * <p>Cross-platform stamp file location (no external deps):
+ *
+ * <ul>
+ *   <li>macOS: {@code ~/Library/Caches/axonflow/java-telemetry-last-sent}
+ *   <li>Linux: {@code $XDG_CACHE_HOME/axonflow/...} or {@code ~/.cache/axonflow/...}
+ *   <li>Windows: {@code %LOCALAPPDATA%/axonflow/...}
+ * </ul>
+ *
+ * <p>If no cache directory is available (restricted env), the stamp path
+ * is {@code null} and the SDK falls back to "one ping per process" — same
+ * as today's pre-heartbeat behavior. No regression for that runtime.
+ */
+public class HeartbeatState {
+  private static final Logger logger = LoggerFactory.getLogger(HeartbeatState.class);
+
+  /** 7 days in milliseconds. */
+  public static final long HEARTBEAT_INTERVAL_MS = 7L * 24L * 60L * 60L * 1000L;
+
+  /** 1 hour in milliseconds — bounds how often we stat() the stamp file. */
+  public static final long HEARTBEAT_GUARD_INTERVAL_MS = 60L * 60L * 1000L;
+
+  private final ReentrantLock lock = new ReentrantLock();
+  private long lastCheckedMillis = -1L;
+  private boolean inFlight = false;
+  private final Path stampPath;
+
+  /**
+   * Default constructor: stamp path resolved via the OS-native cache dir.
+   */
+  public HeartbeatState() {
+    this(resolveStampPath());
+  }
+
+  /**
+   * Test-friendly constructor. Pass {@code null} to test the "no
+   * persistence" path (Lambda-like restricted env).
+   */
+  public HeartbeatState(Path stampPath) {
+    this.stampPath = stampPath;
+  }
+
+  /**
+   * Resolve the OS-native stamp file path, or {@code null} if no
+   * user-writable cache directory is available. Hand-rolled rather than
+   * via a third-party platform-paths library to keep the SDK
+   * dependency-free.
+   */
+  public static Path resolveStampPath() {
+    String osName = System.getProperty("os.name", "").toLowerCase();
+    String userHome = System.getProperty("user.home");
+    if (osName.contains("mac")) {
+      if (userHome == null || userHome.isEmpty()) {
+        return null;
+      }
+      return Paths.get(userHome, "Library", "Caches", "axonflow", "java-telemetry-last-sent");
+    }
+    if (osName.contains("win")) {
+      String localAppData = System.getenv("LOCALAPPDATA");
+      if (localAppData == null || localAppData.isEmpty()) {
+        return null;
+      }
+      return Paths.get(localAppData, "axonflow", "java-telemetry-last-sent");
+    }
+    // Linux / *BSD / others — XDG.
+    String xdg = System.getenv("XDG_CACHE_HOME");
+    if (xdg != null && !xdg.isEmpty()) {
+      return Paths.get(xdg, "axonflow", "java-telemetry-last-sent");
+    }
+    if (userHome == null || userHome.isEmpty()) {
+      return null;
+    }
+    return Paths.get(userHome, ".cache", "axonflow", "java-telemetry-last-sent");
+  }
+
+  /** Read accessor for tests. */
+  public Path getStampPath() {
+    return stampPath;
+  }
+
+  /**
+   * Returns the stamp file's mtime in ms-since-epoch, or {@code -1L} if
+   * absent / unreadable / no path. Tolerant of every failure mode — a
+   * corrupted or missing stamp is treated as "never sent" so we re-attempt.
+   */
+  public long readStampMtimeMillis() {
+    if (stampPath == null) {
+      return -1L;
+    }
+    try {
+      return Files.getLastModifiedTime(stampPath).toMillis();
+    } catch (IOException e) {
+      return -1L;
+    }
+  }
+
+  /**
+   * Atomically write a fresh timestamp file via tmp+rename. Contents are
+   * advisory (a single human-readable line); the SDK uses mtime as the
+   * source of truth, never the contents.
+   *
+   * <p>Errors are non-fatal — a failed write means the next process
+   * retries on schedule, which is preferable to silent dropping.
+   */
+  public void writeStampAtomic() {
+    if (stampPath == null) {
+      return;
+    }
+    try {
+      Files.createDirectories(stampPath.getParent());
+    } catch (IOException e) {
+      return;
+    }
+    Path tmp;
+    try {
+      tmp = Files.createTempFile(
+          stampPath.getParent(),
+          "telemetry-last-sent-",
+          ".tmp");
+    } catch (IOException e) {
+      return;
+    }
+    try {
+      String line = "last_sent=" + DateTimeFormatter.ISO_INSTANT.format(Instant.now().atOffset(ZoneOffset.UTC));
+      Files.writeString(tmp, line + System.lineSeparator());
+      Files.move(tmp, stampPath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+    } catch (IOException e) {
+      try {
+        Files.deleteIfExists(tmp);
+      } catch (IOException ignored) {
+        /* best-effort cleanup */
+      }
+    }
+  }
+
+  /**
+   * Functional interface for the ping operation that returns delivery
+   * success. Used by {@link #maybeSendHeartbeat} so the heartbeat module
+   * doesn't depend directly on TelemetryReporter (avoids a circular
+   * dependency through the gate).
+   */
+  @FunctionalInterface
+  public interface PingFn {
+    boolean send();
+  }
+
+  /**
+   * Central gate for telemetry pings. Called from {@code AxonFlow}'s
+   * constructor and {@code executeHttp} wrapper. Implements the
+   * delivered-heartbeat contract documented at the top of this class.
+   *
+   * <p>Never throws — heartbeat failures must not surface to the caller.
+   *
+   * @param isTelemetryEnabled gating decision from the caller's
+   *     mode/config check; if {@code false} the gate short-circuits.
+   * @param pingFn callback that performs the actual ping. Returns
+   *     {@code true} only on successful delivery; the stamp is written
+   *     ONLY when this returns {@code true}.
+   */
+  public void maybeSendHeartbeat(boolean isTelemetryEnabled, PingFn pingFn) {
+    maybeSendHeartbeat(isTelemetryEnabled, System.getenv("AXONFLOW_TELEMETRY"), pingFn);
+  }
+
+  /**
+   * Package-private overload that accepts the {@code AXONFLOW_TELEMETRY}
+   * env-var value as a parameter. Used by tests to avoid being suppressed
+   * by the surefire/failsafe pom.xml env injection that pins the variable
+   * to {@code off} during automated runs.
+   */
+  void maybeSendHeartbeat(boolean isTelemetryEnabled, String envOptOut, PingFn pingFn) {
+    if (envOptOut != null && "off".equalsIgnoreCase(envOptOut.trim())) {
+      return;
+    }
+    if (!isTelemetryEnabled) {
+      return;
+    }
+
+    long now = System.currentTimeMillis();
+
+    boolean shouldPing;
+    lock.lock();
+    try {
+      if (inFlight) {
+        return;
+      }
+      if (lastCheckedMillis >= 0 && (now - lastCheckedMillis) < HEARTBEAT_GUARD_INTERVAL_MS) {
+        return;
+      }
+      lastCheckedMillis = now;
+
+      long mtime = readStampMtimeMillis();
+      if (mtime > 0 && (now - mtime) < HEARTBEAT_INTERVAL_MS) {
+        return;
+      }
+
+      inFlight = true;
+      shouldPing = true;
+    } finally {
+      lock.unlock();
+    }
+
+    if (!shouldPing) {
+      return;
+    }
+
+    boolean ok;
+    try {
+      ok = pingFn.send();
+    } catch (RuntimeException e) {
+      logger.debug("heartbeat ping threw, treating as failure", e);
+      ok = false;
+    }
+
+    lock.lock();
+    try {
+      inFlight = false;
+      if (ok) {
+        writeStampAtomic();
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  // ---- test helpers ----
+
+  /** Test-only: force {@code lastCheckedMillis}. */
+  void setLastCheckedMillisForTest(long value) {
+    lock.lock();
+    try {
+      lastCheckedMillis = value;
+    } finally {
+      lock.unlock();
+    }
+  }
+}

--- a/src/main/java/com/getaxonflow/sdk/telemetry/TelemetryReporter.java
+++ b/src/main/java/com/getaxonflow/sdk/telemetry/TelemetryReporter.java
@@ -105,7 +105,25 @@ public class TelemetryReporter {
       }
       return;
     }
+    sendPingNow(mode, sdkEndpoint, debug, checkpointUrl);
+  }
 
+  /**
+   * Send a single telemetry ping and return whether it landed.
+   *
+   * <p>Returns {@code true} only when the POST received a 2xx response.
+   * Network failures, timeouts, and non-2xx responses all return
+   * {@code false}. Used by the heartbeat orchestrator (see
+   * {@link HeartbeatState}) where the boolean drives stamp-on-DELIVERY
+   * semantics: only successful POSTs advance the stamp file.
+   *
+   * <p>The caller is responsible for the gating decision — this method
+   * does NOT consult AXONFLOW_TELEMETRY, isEnabled, the stamp file, or
+   * any rate-limit state. That separation lets the heartbeat module make
+   * the gating decision once and only update the stamp on success.
+   */
+  public static boolean sendPingNow(
+      String mode, String sdkEndpoint, boolean debug, String checkpointUrl) {
     logger.info(
         "AxonFlow: anonymous telemetry enabled. Opt out: AXONFLOW_TELEMETRY=off | https://docs.getaxonflow.com/docs/telemetry");
 
@@ -114,23 +132,10 @@ public class TelemetryReporter {
 
     String endpointType = classifyEndpoint(sdkEndpoint);
 
-    // Send synchronously with a single bounded deadline shared across the
-    // /health probe and the checkpoint POST. A CompletableFuture.runAsync
-    // here would default to ForkJoinPool.commonPool (daemon threads) which
-    // die at JVM exit, silently dropping the ping for short-lived JVMs (CLI
-    // binaries, Lambda handlers, serverless cold-starts, quickstart scripts).
-    // See axonflow-enterprise#1706.
-    //
-    // Blocks the caller briefly (~350ms warm / ~1.3s cold on a reachable
-    // checkpoint; bounded at TIMEOUT_SECONDS on an unreachable one). That is
-    // acceptable for a control-plane SDK's construction path, and matches
-    // the pattern shipped for the Go SDK in axonflow-enterprise#1693.
     try {
       long deadlineMs =
           System.nanoTime() / 1_000_000L + TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS);
 
-      // Health probe gets up to 1s of the remaining budget, so the POST
-      // always has room even when the probe fully consumes its slice.
       long healthBudgetMs =
           Math.min(
               TimeUnit.SECONDS.toMillis(1),
@@ -144,7 +149,7 @@ public class TelemetryReporter {
 
       long postBudgetMs = Math.max(0L, deadlineMs - System.nanoTime() / 1_000_000L);
       if (postBudgetMs < MIN_BUDGET_MS) {
-        return;
+        return false;
       }
 
       OkHttpClient client =
@@ -161,12 +166,14 @@ public class TelemetryReporter {
         if (debug) {
           logger.debug("Telemetry ping sent, status={}", response.code());
         }
+        return response.isSuccessful();
       }
     } catch (Exception e) {
       // Silent failure - telemetry must never disrupt SDK operation
       if (debug) {
         logger.debug("Telemetry ping failed (silent): {}", e.getMessage());
       }
+      return false;
     }
   }
 
@@ -192,13 +199,13 @@ public class TelemetryReporter {
    *     in default logic)
    * @return true if telemetry should be sent
    */
-  static boolean isEnabled(String mode, Boolean configOverride, boolean hasCredentials) {
+  public static boolean isEnabled(String mode, Boolean configOverride, boolean hasCredentials) {
     return isEnabled(
         mode, configOverride, hasCredentials, System.getenv("AXONFLOW_TELEMETRY"));
   }
 
   /** Package-private for testing. Accepts env var values as parameters. */
-  static boolean isEnabled(
+  public static boolean isEnabled(
       String mode, Boolean configOverride, boolean hasCredentials, String axonflowTelemetry) {
     if (axonflowTelemetry != null && "off".equalsIgnoreCase(axonflowTelemetry.trim())) {
       return false;

--- a/src/test/java/com/getaxonflow/sdk/telemetry/HeartbeatStateE2ETest.java
+++ b/src/test/java/com/getaxonflow/sdk/telemetry/HeartbeatStateE2ETest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 AxonFlow
+ * Licensed under the Business Source License 1.1.
+ */
+package com.getaxonflow.sdk.telemetry;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * 4-run cross-process E2E mirroring the Go reference (see
+ * {@code heartbeat_e2e_test.go}). Validates the delivered-stamp contract
+ * end-to-end against a real WireMock HTTP server:
+ *
+ * <pre>
+ *   Run 1: cold start (no stamp)              → 1 ping;  stamp present
+ *   Run 2: immediate re-run (fresh stamp)     → 0 pings; stamp unchanged
+ *   Run 3: backdate stamp 8d                  → 1 ping;  stamp re-touched
+ *   Run 4: backdate stamp 8d, mock returns 503 → ping attempted but stamp NOT advanced;
+ *                                                retry against 200-mock fires + lands cleanly
+ * </pre>
+ *
+ * <p>The Java equivalent of Go's {@code t.Setenv("AXONFLOW_CHECKPOINT_URL")}
+ * + {@code replaceHeartbeatStateForTest(stampPath)} pattern is to drive
+ * the gate directly via {@link HeartbeatState#replaceForTest(Path)} and
+ * pass an inline {@link HeartbeatState.PingFn} that POSTs to WireMock —
+ * Java's {@code System.getenv} is immutable post-launch, so we cannot
+ * inject AXONFLOW_CHECKPOINT_URL on a per-test basis the way Go can.
+ *
+ * <p>Each run installs a fresh in-memory gate at the SAME stamp path —
+ * exactly the cross-run invariant the Go E2E exercises (the stamp file
+ * is the source of truth across simulated process restarts).
+ */
+@WireMockTest
+@DisplayName("HeartbeatState — 4-run cross-process E2E")
+class HeartbeatStateE2ETest {
+
+  @Test
+  @DisplayName("Cold → warm → stale → 503 → retry, with delivered-stamp semantics")
+  void fourRunCycle(WireMockRuntimeInfo wm, @TempDir Path tmp) throws IOException {
+    Path stampPath = tmp.resolve("java-telemetry-last-sent");
+
+    // Always-200 endpoint for runs 1, 2, 3 and the retry leg of run 4.
+    WireMock.stubFor(
+        post(urlMatching("/v1/.*"))
+            .withName("ok")
+            .willReturn(aResponse().withStatus(200).withBody("{\"ok\":true}")));
+    String okUrl = wm.getHttpBaseUrl() + "/v1/checkpoint";
+
+    // Always-503 endpoint for run 4's failure leg.
+    WireMock.stubFor(
+        post(urlMatching("/v1/fail.*"))
+            .withName("fail")
+            .willReturn(aResponse().withStatus(503)));
+    String failUrl = wm.getHttpBaseUrl() + "/v1/fail";
+
+    // Save the process-global singleton and restore it at the end so we
+    // don't leak gate state into other tests in the suite.
+    HeartbeatState previous = HeartbeatState.replaceForTest(stampPath);
+    try {
+      // Each run mirrors a "new process": fresh in-memory gate at the
+      // same stamp path. Mode/credentials don't matter for this test —
+      // the gate's only contract is "fire the PingFn, write stamp on
+      // success" — so we drive it directly with isTelemetryEnabled=true.
+
+      // ----- Run 1: cold start, no stamp → 1 ping, stamp present ---------------
+      WireMock.resetAllRequests();
+      runOnceAt(stampPath, okUrl);
+      assertThat(WireMock.getAllServeEvents())
+          .as("Run 1 (cold): expected exactly 1 ping")
+          .hasSize(1);
+      assertThat(Files.exists(stampPath))
+          .as("Run 1 (cold): expected stamp file present")
+          .isTrue();
+      long stampMtimeAfterRun1 = Files.getLastModifiedTime(stampPath).toMillis();
+
+      // ----- Run 2: immediate re-run, fresh stamp → 0 pings -------------------
+      WireMock.resetAllRequests();
+      runOnceAt(stampPath, okUrl);
+      WireMock.verify(0, postRequestedFor(urlMatching("/v1/.*")));
+      assertThat(Files.getLastModifiedTime(stampPath).toMillis())
+          .as("Run 2 (warm): stamp unchanged")
+          .isEqualTo(stampMtimeAfterRun1);
+
+      // ----- Run 3: backdate stamp 8d → 1 ping + stamp re-touched -------------
+      Files.setLastModifiedTime(
+          stampPath, FileTime.from(Instant.now().minus(8, ChronoUnit.DAYS)));
+      long stampMtimeBeforeRun3 = Files.getLastModifiedTime(stampPath).toMillis();
+
+      WireMock.resetAllRequests();
+      runOnceAt(stampPath, okUrl);
+      assertThat(WireMock.getAllServeEvents())
+          .as("Run 3 (stale): expected exactly 1 ping after backdating stamp")
+          .hasSize(1);
+      long stampMtimeAfterRun3 = Files.getLastModifiedTime(stampPath).toMillis();
+      assertThat(stampMtimeAfterRun3)
+          .as("Run 3 (stale): stamp mtime must advance after successful ping")
+          .isGreaterThan(stampMtimeBeforeRun3);
+      assertThat(System.currentTimeMillis() - stampMtimeAfterRun3)
+          .as("Run 3 (stale): stamp mtime is recent")
+          .isLessThan(5_000L);
+
+      // ----- Run 4 (failure): backdate stamp 8d, point at 503 -----------------
+      // Expectation: ping is attempted but stamp is NOT advanced.
+      Files.setLastModifiedTime(
+          stampPath, FileTime.from(Instant.now().minus(8, ChronoUnit.DAYS)));
+      long stampMtimeBeforeFail = Files.getLastModifiedTime(stampPath).toMillis();
+
+      WireMock.resetAllRequests();
+      runOnceAt(stampPath, failUrl);
+      assertThat(WireMock.getAllServeEvents())
+          .as("Run 4 (failure): expected exactly 1 attempt against 503 endpoint")
+          .hasSize(1);
+      long stampMtimeAfterFail = Files.getLastModifiedTime(stampPath).toMillis();
+      assertThat(stampMtimeAfterFail)
+          .as("Run 4 (failure): stamp mtime must NOT advance on failed POST")
+          .isEqualTo(stampMtimeBeforeFail);
+
+      // ----- Run 4 (retry): same stale stamp, point at 200 --------------------
+      WireMock.resetAllRequests();
+      runOnceAt(stampPath, okUrl);
+      assertThat(WireMock.getAllServeEvents())
+          .as("Run 4 (retry): expected exactly 1 ping when stamp still stale and server now 200")
+          .hasSize(1);
+      long stampMtimeAfterRetry = Files.getLastModifiedTime(stampPath).toMillis();
+      assertThat(System.currentTimeMillis() - stampMtimeAfterRetry)
+          .as("Run 4 (retry): stamp mtime advanced to ~now after successful retry")
+          .isLessThan(5_000L);
+    } finally {
+      HeartbeatState.restoreForTest(previous);
+    }
+  }
+
+  /**
+   * Simulate a "new process": install a fresh in-memory gate at the
+   * SAME stamp path (cross-run invariant) and run the gate once with
+   * an inline ping that POSTs to {@code targetUrl}. Returns once the
+   * gate's stamp write — if any — has settled, since
+   * {@link HeartbeatState#maybeSendHeartbeat} is synchronous.
+   */
+  private static void runOnceAt(Path stampPath, String targetUrl) {
+    HeartbeatState.replaceForTest(stampPath);
+    HeartbeatState.shared()
+        .maybeSendHeartbeat(
+            true,
+            null,
+            () -> {
+              try {
+                java.net.HttpURLConnection conn =
+                    (java.net.HttpURLConnection) new java.net.URL(targetUrl).openConnection();
+                conn.setRequestMethod("POST");
+                conn.setDoOutput(true);
+                conn.setConnectTimeout(2_000);
+                conn.setReadTimeout(2_000);
+                conn.getOutputStream().write("{}".getBytes());
+                conn.getOutputStream().close();
+                int code = conn.getResponseCode();
+                conn.disconnect();
+                return code >= 200 && code < 300;
+              } catch (IOException e) {
+                return false;
+              }
+            });
+  }
+}

--- a/src/test/java/com/getaxonflow/sdk/telemetry/HeartbeatStateTest.java
+++ b/src/test/java/com/getaxonflow/sdk/telemetry/HeartbeatStateTest.java
@@ -223,6 +223,47 @@ class HeartbeatStateTest {
   }
 
   @Test
+  @DisplayName("Case 7b (P1 regression): 50 concurrent clients sharing the singleton → exactly 1 ping")
+  void multiClientConcurrent_coalesceToOnePing(@TempDir Path tmp) throws InterruptedException {
+    // Install a single shared HeartbeatState pointing at a temp stamp.
+    // Pre-fix this test would observe up to 50 pings because each AxonFlow
+    // instance held its own HeartbeatState; the static singleton brings
+    // it to 1.
+    HeartbeatState previous = HeartbeatState.replaceForTest(tmp.resolve("stamp"));
+    try {
+      AtomicInteger pings = new AtomicInteger(0);
+      int clientCount = 50;
+      CountDownLatch start = new CountDownLatch(1);
+      CountDownLatch done = new CountDownLatch(clientCount);
+
+      for (int i = 0; i < clientCount; i++) {
+        new Thread(() -> {
+          try {
+            start.await();
+          } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+          }
+          // Each "client" calls the shared gate. The static singleton coalesces
+          // them onto a single ping per heartbeatInterval.
+          HeartbeatState.shared().maybeSendHeartbeat(true, null, () -> {
+            try { Thread.sleep(10); } catch (InterruptedException ignored) {}
+            pings.incrementAndGet();
+            return true;
+          });
+          done.countDown();
+        }, "multi-client-test-" + i).start();
+      }
+
+      start.countDown();
+      done.await();
+
+      assertThat(pings.get()).isEqualTo(1);
+    } finally {
+      HeartbeatState.restoreForTest(previous);
+    }
+  }
+
+  @Test
   @DisplayName("Case 9: ping returns false → stamp NOT written; retry on success works")
   void pingFailure_stampNotWritten_retrySucceeds(@TempDir Path tmp) throws IOException {
     Path stamp = tmp.resolve("stamp");

--- a/src/test/java/com/getaxonflow/sdk/telemetry/HeartbeatStateTest.java
+++ b/src/test/java/com/getaxonflow/sdk/telemetry/HeartbeatStateTest.java
@@ -223,12 +223,13 @@ class HeartbeatStateTest {
   }
 
   @Test
-  @DisplayName("Case 7b (P1 regression): 50 concurrent clients sharing the singleton → exactly 1 ping")
+  @DisplayName("Case 7b: 50 concurrent callers via shared() → exactly 1 ping (singleton gate)")
   void multiClientConcurrent_coalesceToOnePing(@TempDir Path tmp) throws InterruptedException {
-    // Install a single shared HeartbeatState pointing at a temp stamp.
-    // Pre-fix this test would observe up to 50 pings because each AxonFlow
-    // instance held its own HeartbeatState; the static singleton brings
-    // it to 1.
+    // Verifies the SINGLETON gate (HeartbeatState.shared()) coalesces
+    // concurrent callers to a single ping. End-to-end coverage that the
+    // AxonFlow constructor actually routes through shared() (the P1 fix
+    // for per-instance gates) lives in HeartbeatE2ETest, which constructs
+    // real AxonFlow instances against an httptest checkpoint.
     HeartbeatState previous = HeartbeatState.replaceForTest(tmp.resolve("stamp"));
     try {
       AtomicInteger pings = new AtomicInteger(0);

--- a/src/test/java/com/getaxonflow/sdk/telemetry/HeartbeatStateTest.java
+++ b/src/test/java/com/getaxonflow/sdk/telemetry/HeartbeatStateTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2026 AxonFlow
+ * Licensed under the Business Source License 1.1.
+ */
+package com.getaxonflow.sdk.telemetry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * 9-case matrix mirroring the Go SDK reference (see heartbeat_test.go).
+ *
+ * <pre>
+ *   1. cold start, no stamp           → 1 ping fires, stamp written
+ *   2. fresh stamp (1d old)           → 0 pings
+ *   3. stale stamp (8d old)           → 1 ping, stamp updated
+ *   4. 5 calls within 1h cache        → exactly 1 ping
+ *   5. cache expired + stale stamp    → 2nd ping fires
+ *   6. AXONFLOW_TELEMETRY=off mid-run → covered by Java tests via mode/config gating;
+ *      the env-var path requires process-level env mutation which JUnit cannot
+ *      portably mutate, so we exercise the equivalent code path by passing
+ *      isTelemetryEnabled=false on the second call.
+ *   7. 100 concurrent threads         → exactly 1 ping (stampede coalesced)
+ *   8. no cache dir (stampPath=null)  → ping per process, no crash
+ *   9. ping returns false             → stamp NOT written; retry on success works
+ * </pre>
+ */
+@DisplayName("HeartbeatState — 9-case matrix")
+class HeartbeatStateTest {
+
+  @Test
+  @DisplayName("Case 1: cold start, no stamp → 1 ping, stamp written")
+  void coldStart_noStamp_firesOnce(@TempDir Path tmp) {
+    Path stamp = tmp.resolve("stamp");
+    HeartbeatState h = new HeartbeatState(stamp);
+    AtomicInteger pings = new AtomicInteger(0);
+
+    h.maybeSendHeartbeat(true, null, () -> {
+      pings.incrementAndGet();
+      return true;
+    });
+
+    assertThat(pings.get()).isEqualTo(1);
+    assertThat(Files.exists(stamp)).isTrue();
+  }
+
+  @Test
+  @DisplayName("Case 2: fresh stamp (1d old) → 0 pings")
+  void freshStamp_doesNotFire(@TempDir Path tmp) throws IOException {
+    Path stamp = tmp.resolve("stamp");
+    Files.createDirectories(stamp.getParent());
+    Files.writeString(stamp, "last_sent=test\n");
+    Files.setLastModifiedTime(stamp, FileTime.from(Instant.now().minus(1, ChronoUnit.DAYS)));
+
+    HeartbeatState h = new HeartbeatState(stamp);
+    AtomicInteger pings = new AtomicInteger(0);
+    h.maybeSendHeartbeat(true, null, () -> {
+      pings.incrementAndGet();
+      return true;
+    });
+
+    assertThat(pings.get()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("Case 3: stale stamp (8d old) → 1 ping, stamp updated")
+  void staleStamp_firesAndUpdates(@TempDir Path tmp) throws IOException {
+    Path stamp = tmp.resolve("stamp");
+    Files.createDirectories(stamp.getParent());
+    Files.writeString(stamp, "last_sent=test\n");
+    Files.setLastModifiedTime(stamp, FileTime.from(Instant.now().minus(8, ChronoUnit.DAYS)));
+
+    HeartbeatState h = new HeartbeatState(stamp);
+    AtomicInteger pings = new AtomicInteger(0);
+    h.maybeSendHeartbeat(true, null, () -> {
+      pings.incrementAndGet();
+      return true;
+    });
+
+    assertThat(pings.get()).isEqualTo(1);
+    long mtime = Files.getLastModifiedTime(stamp).toMillis();
+    assertThat(System.currentTimeMillis() - mtime).isLessThan(5000L);
+  }
+
+  @Test
+  @DisplayName("Case 4: 5 calls within 1h cache → exactly 1 ping")
+  void within1hCache_firesOnce(@TempDir Path tmp) {
+    HeartbeatState h = new HeartbeatState(tmp.resolve("stamp"));
+    AtomicInteger pings = new AtomicInteger(0);
+
+    for (int i = 0; i < 5; i++) {
+      h.maybeSendHeartbeat(true, null, () -> {
+        pings.incrementAndGet();
+        return true;
+      });
+    }
+
+    assertThat(pings.get()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("Case 5: cache expired + stale stamp → 2nd ping fires")
+  void afterCacheExpiry_firesAgain(@TempDir Path tmp) throws IOException {
+    Path stamp = tmp.resolve("stamp");
+    HeartbeatState h = new HeartbeatState(stamp);
+    AtomicInteger pings = new AtomicInteger(0);
+
+    h.maybeSendHeartbeat(true, null, () -> {
+      pings.incrementAndGet();
+      return true;
+    });
+    assertThat(pings.get()).isEqualTo(1);
+
+    // Backdate cache (2h ago) AND stamp file (8d ago).
+    h.setLastCheckedMillisForTest(System.currentTimeMillis() - 2 * 60 * 60 * 1000L);
+    Files.setLastModifiedTime(stamp, FileTime.from(Instant.now().minus(8, ChronoUnit.DAYS)));
+
+    h.maybeSendHeartbeat(true, null, () -> {
+      pings.incrementAndGet();
+      return true;
+    });
+    assertThat(pings.get()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("Case 6: telemetry disabled mid-run → 0 further pings, stamp unchanged")
+  void disabledMidProcess_stopsPings(@TempDir Path tmp) throws IOException {
+    Path stamp = tmp.resolve("stamp");
+    HeartbeatState h = new HeartbeatState(stamp);
+    AtomicInteger pings = new AtomicInteger(0);
+
+    h.maybeSendHeartbeat(true, null, () -> {
+      pings.incrementAndGet();
+      return true;
+    });
+    assertThat(pings.get()).isEqualTo(1);
+
+    // Disable telemetry, force gates open, snapshot mtime AFTER manipulation.
+    h.setLastCheckedMillisForTest(System.currentTimeMillis() - 2 * 60 * 60 * 1000L);
+    Files.setLastModifiedTime(stamp, FileTime.from(Instant.now().minus(8, ChronoUnit.DAYS)));
+    long mtimeBefore = Files.getLastModifiedTime(stamp).toMillis();
+
+    h.maybeSendHeartbeat(false, null, () -> {
+      pings.incrementAndGet();
+      return true;
+    });
+
+    assertThat(pings.get()).isEqualTo(1);
+    long mtimeAfter = Files.getLastModifiedTime(stamp).toMillis();
+    assertThat(mtimeAfter).isEqualTo(mtimeBefore);
+  }
+
+  @Test
+  @DisplayName("Case 7: 100 concurrent threads → exactly 1 ping")
+  void concurrentCallers_coalesceToOnePing(@TempDir Path tmp) throws InterruptedException {
+    HeartbeatState h = new HeartbeatState(tmp.resolve("stamp"));
+    AtomicInteger pings = new AtomicInteger(0);
+
+    int threadCount = 100;
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(threadCount);
+
+    for (int i = 0; i < threadCount; i++) {
+      new Thread(() -> {
+        try {
+          start.await();
+        } catch (InterruptedException ignored) {
+          Thread.currentThread().interrupt();
+        }
+        h.maybeSendHeartbeat(true, null, () -> {
+          // Slow ping to encourage stampede behavior.
+          try { Thread.sleep(10); } catch (InterruptedException ignored) {}
+          pings.incrementAndGet();
+          return true;
+        });
+        done.countDown();
+      }, "heartbeat-test-" + i).start();
+    }
+
+    start.countDown();
+    done.await();
+
+    assertThat(pings.get()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("Case 8: no cache dir (stampPath=null) → ping per process, no crash")
+  void noCacheDir_pingsButNoStamp() {
+    HeartbeatState h = new HeartbeatState((Path) null);
+    AtomicInteger pings = new AtomicInteger(0);
+
+    h.maybeSendHeartbeat(true, null, () -> {
+      pings.incrementAndGet();
+      return true;
+    });
+    assertThat(pings.get()).isEqualTo(1);
+
+    // 1h cache holds within the same process even without a stamp file.
+    h.maybeSendHeartbeat(true, null, () -> {
+      pings.incrementAndGet();
+      return true;
+    });
+    assertThat(pings.get()).isEqualTo(1);
+
+    // Backdate cache, call again — fires because no stamp gate exists.
+    h.setLastCheckedMillisForTest(System.currentTimeMillis() - 2 * 60 * 60 * 1000L);
+    h.maybeSendHeartbeat(true, null, () -> {
+      pings.incrementAndGet();
+      return true;
+    });
+    assertThat(pings.get()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("Case 9: ping returns false → stamp NOT written; retry on success works")
+  void pingFailure_stampNotWritten_retrySucceeds(@TempDir Path tmp) throws IOException {
+    Path stamp = tmp.resolve("stamp");
+    HeartbeatState h = new HeartbeatState(stamp);
+    AtomicInteger fails = new AtomicInteger(0);
+    AtomicInteger successes = new AtomicInteger(0);
+
+    h.maybeSendHeartbeat(true, null, () -> {
+      fails.incrementAndGet();
+      return false;
+    });
+    assertThat(fails.get()).isEqualTo(1);
+    assertThat(Files.exists(stamp)).isFalse();
+
+    // Backdate cache, retry against success.
+    h.setLastCheckedMillisForTest(System.currentTimeMillis() - 2 * 60 * 60 * 1000L);
+
+    h.maybeSendHeartbeat(true, null, () -> {
+      successes.incrementAndGet();
+      return true;
+    });
+    assertThat(successes.get()).isEqualTo(1);
+    assertThat(Files.exists(stamp)).isTrue();
+  }
+}

--- a/tests/heartbeat-real-stack/SmokeJava.java
+++ b/tests/heartbeat-real-stack/SmokeJava.java
@@ -1,0 +1,72 @@
+/*
+ * Cross-platform real-stack smoke for the Java SDK.
+ *
+ * Reads:
+ *   AXONFLOW_AGENT_URL       — fake agent base URL
+ *   AXONFLOW_CHECKPOINT_URL  — fake checkpoint URL
+ *
+ * Constructs AxonFlow.create(...) and verifies the constructor's
+ * heartbeat fires plus the stamp lands at the OS-native cache path.
+ *
+ * NOTE: The Java SDK resolves the cache dir via
+ * System.getProperty("user.home"), not getenv("HOME"). On macOS the JVM
+ * ignores $HOME for user.home — call this with -Duser.home=$HOME or
+ * the path will leak to the real cache.
+ */
+import com.getaxonflow.sdk.AxonFlow;
+import com.getaxonflow.sdk.AxonFlowConfig;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class SmokeJava {
+  public static void main(String[] args) throws Exception {
+    String agent = System.getenv("AXONFLOW_AGENT_URL");
+    if (agent == null || agent.isEmpty()) {
+      System.err.println("FAIL: AXONFLOW_AGENT_URL not set");
+      System.exit(1);
+    }
+
+    Path expected = stampPath();
+
+    try (AxonFlow client =
+        AxonFlow.create(
+            AxonFlowConfig.builder()
+                .agentUrl(agent)
+                .clientId("smoke-test")
+                .clientSecret("smoke-secret")
+                .build())) {
+      try {
+        client.healthCheck();
+      } catch (Exception ignored) {
+        // best-effort
+      }
+    }
+    // Constructor's invokeHeartbeat is synchronous; small grace window
+    // for the executor's request-path heartbeat to flush.
+    Thread.sleep(500);
+
+    if (!Files.exists(expected)) {
+      System.err.println("FAIL: stamp not at " + expected);
+      System.exit(1);
+    }
+    System.out.println("OK: stamp at " + expected);
+  }
+
+  private static Path stampPath() {
+    String osName = System.getProperty("os.name", "").toLowerCase();
+    String userHome = System.getProperty("user.home");
+    if (osName.contains("mac")) {
+      return Paths.get(userHome, "Library", "Caches", "axonflow", "java-telemetry-last-sent");
+    }
+    if (osName.contains("win")) {
+      String localAppData = System.getenv("LOCALAPPDATA");
+      return Paths.get(localAppData, "axonflow", "java-telemetry-last-sent");
+    }
+    String xdg = System.getenv("XDG_CACHE_HOME");
+    if (xdg != null && !xdg.isEmpty()) {
+      return Paths.get(xdg, "axonflow", "java-telemetry-last-sent");
+    }
+    return Paths.get(userHome, ".cache", "axonflow", "java-telemetry-last-sent");
+  }
+}

--- a/tests/heartbeat-real-stack/run_real_stack.py
+++ b/tests/heartbeat-real-stack/run_real_stack.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Cross-platform driver for the heartbeat real-stack E2E.
+
+Stands up the fake checkpoint server (server.py), runs an SDK smoke
+twice, and verifies:
+
+  Cold (first run):  exactly 1 checkpoint hit, stamp file present
+  Warm (second run): 0 additional checkpoint hits, stamp unchanged
+
+Usage:
+    python run_real_stack.py <smoke_command...>
+
+The smoke command is invoked twice with these environment variables set:
+    AXONFLOW_AGENT_URL
+    AXONFLOW_CHECKPOINT_URL
+    AXONFLOW_TELEMETRY=""        (defensive; CI workflows often default to off)
+    HOME, USERPROFILE, LOCALAPPDATA, XDG_CACHE_HOME — all rerouted to a
+                                  temp dir so the smoke can verify a clean
+                                  cache state without touching the runner's
+                                  real cache.
+
+Exits 0 on success, non-zero on any failure.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+
+def fetch_counter(url: str) -> dict:
+    with urllib.request.urlopen(url + "/__counter", timeout=5) as r:
+        return json.loads(r.read())
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("Usage: run_real_stack.py <smoke_command...>", file=sys.stderr)
+        return 2
+
+    smoke_cmd = list(argv[1:])
+    # Java quirk: the JVM resolves user.home from native APIs at startup
+    # and ignores $HOME on macOS / Windows. Detect and rewrite.
+    java_target = any("java" == os.path.basename(p).lower().replace(".exe", "") for p in [smoke_cmd[0]])
+    here = Path(__file__).resolve().parent
+    server_script = here / "server.py"
+
+    work_root = Path(tempfile.mkdtemp(prefix="hb-real-stack-"))
+    port_file = work_root / "port.txt"
+
+    env = os.environ.copy()
+    env["HEARTBEAT_E2E_PORT_FILE"] = str(port_file)
+
+    # Launch fake server.
+    server_proc = subprocess.Popen(
+        [sys.executable, str(server_script)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    try:
+        # Wait for port file to appear.
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            if port_file.exists():
+                port_text = port_file.read_text().strip()
+                if port_text:
+                    break
+            time.sleep(0.1)
+        else:
+            print("FAIL: server didn't write port file in 15s", file=sys.stderr)
+            return 1
+
+        port = int(port_text)
+        server_url = f"http://127.0.0.1:{port}"
+        print(f"server: {server_url}")
+
+        # Sanity check.
+        before = fetch_counter(server_url)
+        assert before == {"checkpoint_hits": 0, "health_hits": 0}, before
+
+        # Build a clean HOME / cache redirect.
+        clean_home = work_root / "home"
+        clean_home.mkdir()
+
+        smoke_env = os.environ.copy()
+        smoke_env.update({
+            "AXONFLOW_AGENT_URL": server_url,
+            "AXONFLOW_CHECKPOINT_URL": f"{server_url}/v1/ping",
+            "AXONFLOW_TELEMETRY": "",
+            # Reroute cache dir on every OS:
+            "HOME": str(clean_home),                         # macOS, Linux
+            "USERPROFILE": str(clean_home),                  # Windows
+            "LOCALAPPDATA": str(clean_home / "AppData" / "Local"),  # Windows
+            "XDG_CACHE_HOME": str(clean_home / ".cache"),    # Linux
+        })
+        # Ensure those nested dirs exist for Windows.
+        Path(smoke_env["LOCALAPPDATA"]).mkdir(parents=True, exist_ok=True)
+        Path(smoke_env["XDG_CACHE_HOME"]).mkdir(parents=True, exist_ok=True)
+
+        # Java JVM ignores $HOME for user.home on macOS / Windows; pass
+        # -Duser.home=<clean_home> as the first JVM arg.
+        if java_target:
+            smoke_cmd[1:1] = [f"-Duser.home={clean_home}"]
+
+        # ---- Cold run ----
+        print("--- cold run ---")
+        cold = subprocess.run(smoke_cmd, env=smoke_env, capture_output=True, text=True)
+        sys.stdout.write(cold.stdout)
+        sys.stderr.write(cold.stderr)
+        if cold.returncode != 0:
+            print(f"FAIL: cold smoke exited {cold.returncode}", file=sys.stderr)
+            return 1
+
+        cold_counter = fetch_counter(server_url)
+        print(f"counter after cold: {cold_counter}")
+        if cold_counter["checkpoint_hits"] != 1:
+            print(
+                f"FAIL: expected 1 checkpoint hit on cold, got {cold_counter['checkpoint_hits']}",
+                file=sys.stderr,
+            )
+            return 1
+
+        # ---- Warm run (same clean_home, stamp now exists) ----
+        print("--- warm run ---")
+        warm = subprocess.run(smoke_cmd, env=smoke_env, capture_output=True, text=True)
+        sys.stdout.write(warm.stdout)
+        sys.stderr.write(warm.stderr)
+        if warm.returncode != 0:
+            print(f"FAIL: warm smoke exited {warm.returncode}", file=sys.stderr)
+            return 1
+
+        warm_counter = fetch_counter(server_url)
+        print(f"counter after warm: {warm_counter}")
+        delta = warm_counter["checkpoint_hits"] - cold_counter["checkpoint_hits"]
+        if delta != 0:
+            print(
+                f"FAIL: expected 0 additional pings on warm run, got {delta}",
+                file=sys.stderr,
+            )
+            return 1
+
+        print("\nOK: cold + warm pass — heartbeat real-stack contract holds")
+        return 0
+    finally:
+        server_proc.terminate()
+        try:
+            server_proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            server_proc.kill()
+        shutil.rmtree(work_root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/heartbeat-real-stack/run_real_stack.py
+++ b/tests/heartbeat-real-stack/run_real_stack.py
@@ -66,16 +66,42 @@ def main(argv: list[str]) -> int:
     )
 
     try:
-        # Wait for port file to appear.
-        deadline = time.time() + 15
+        # Wait for port file to appear. 60s is generous — macos-latest GitHub
+        # runners can be slow to cold-start Python; 15s sometimes wasn't enough.
+        # On any timeout we surface the server's stdout+stderr so the cause is
+        # visible in CI logs instead of failing silently.
+        deadline = time.time() + 60
+        port_text: str | None = None
         while time.time() < deadline:
+            if server_proc.poll() is not None:
+                # Server crashed before writing the port file.
+                stdout_bytes, _ = server_proc.communicate(timeout=2)
+                output = stdout_bytes.decode("utf-8", errors="replace") if stdout_bytes else ""
+                print(
+                    f"FAIL: server exited with code {server_proc.returncode} before writing port file.\n"
+                    f"--- server stdout/stderr ---\n{output}",
+                    file=sys.stderr,
+                )
+                return 1
             if port_file.exists():
                 port_text = port_file.read_text().strip()
                 if port_text:
                     break
             time.sleep(0.1)
-        else:
-            print("FAIL: server didn't write port file in 15s", file=sys.stderr)
+        if not port_text:
+            # Port file timeout — kill server and surface its output.
+            server_proc.terminate()
+            try:
+                stdout_bytes, _ = server_proc.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                server_proc.kill()
+                stdout_bytes, _ = server_proc.communicate()
+            output = stdout_bytes.decode("utf-8", errors="replace") if stdout_bytes else ""
+            print(
+                "FAIL: server didn't write port file in 60s.\n"
+                f"--- server stdout/stderr ---\n{output}",
+                file=sys.stderr,
+            )
             return 1
 
         port = int(port_text)

--- a/tests/heartbeat-real-stack/server.py
+++ b/tests/heartbeat-real-stack/server.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Cross-platform fake-agent + fake-checkpoint server for the heartbeat E2E.
+
+Same as /tmp/heartbeat-real-e2e/server.py but vendored alongside the
+per-SDK smokes so it can ship inside each SDK repo's tests/ directory.
+"""
+import json
+import os
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+CHECKPOINT_HITS = 0
+HEALTH_HITS = 0
+LOCK = threading.Lock()
+SDK_VERSION = "7.4.5"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send_json(self, status, body):
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode())
+
+    def do_GET(self):
+        global HEALTH_HITS
+        if self.path == "/health":
+            with LOCK:
+                HEALTH_HITS += 1
+            self._send_json(200, {"version": SDK_VERSION, "status": "ok"})
+        elif self.path == "/__counter":
+            with LOCK:
+                self._send_json(200, {"checkpoint_hits": CHECKPOINT_HITS, "health_hits": HEALTH_HITS})
+        else:
+            self._send_json(503, {"error": "not implemented"})
+
+    def do_POST(self):
+        global CHECKPOINT_HITS
+        length = int(self.headers.get("Content-Length", "0"))
+        if length:
+            self.rfile.read(length)
+        # Accept both /v1/ping (production path) and /v1/checkpoint (legacy local).
+        if self.path.startswith("/v1/"):
+            with LOCK:
+                CHECKPOINT_HITS += 1
+            self._send_json(200, {"latest_version": SDK_VERSION})
+        else:
+            self._send_json(503, {"error": "not implemented"})
+
+    def log_message(self, *_args):
+        pass
+
+
+def main():
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    host, port = server.server_address
+    base = f"http://{host}:{port}"
+    # Write port to a file so the launcher can read it (more reliable than
+    # parsing stdout under Windows + various shells).
+    with open(os.environ.get("HEARTBEAT_E2E_PORT_FILE", "port.txt"), "w") as f:
+        f.write(str(port))
+    print(f"SERVER_URL={base}", flush=True)
+    sys.stdout.flush()
+
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+
+    try:
+        # Run for up to 5 minutes; CI orchestrator kills us when done.
+        time.sleep(5 * 60)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Move SDK telemetry from "ping per `new AxonFlow()`" to the cross-language contract:

> AxonFlow emits at most one anonymous heartbeat per environment every 7 days during SDK activity.

Mirrors Go SDK reference, Python, TS; contract in axonflow-enterprise.

## How

- New `HeartbeatState` class with cross-platform stamp file, `ReentrantLock`-guarded 1-hour in-memory cache + in-flight flag, **stamp-on-DELIVERY** semantics.
- Single hook point via private `executeHttp(client, request)` wrapper. All 134 raw `httpClient.newCall(req).execute()` / `planHttpClient.newCall(req).execute()` call sites in `AxonFlow.java` migrated.
- `TelemetryReporter.sendPingNow(...): boolean` is the new pure-network function; `sendPing(...)` is the legacy compat shim.
- Test-friendly `maybeSendHeartbeat(boolean, String envOptOut, PingFn)` overload bypasses surefire/failsafe pom.xml's `AXONFLOW_TELEMETRY=off` injection.

## Tests

- `HeartbeatStateTest.java` — 9-case matrix.
- 1221/1221 existing tests still pass.

## Test plan

- [x] `mvn test` green (1221/1221)
- [ ] CI green