### PR TITLE
docs(contributing): require DCO sign-off on every commit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,36 @@
 
 Thank you for your interest in contributing! Please open an issue or pull request via the [GitHub repository](https://github.com/getaxonflow/axonflow-sdk-java).
 
+## Sign your commits — Developer Certificate of Origin (DCO) is required
+
+All contributions to this repository must be **signed off** under the [Developer Certificate of Origin v1.1](https://developercertificate.org/). The DCO is a per-commit affirmation that you wrote the code (or otherwise have the right to submit it) and are licensing it under the same license as the rest of this repository.
+
+Add the sign-off automatically with `-s` (or `--signoff`) on every commit:
+
+```bash
+git commit -s -m "your commit message"
+```
+
+This appends a trailer like:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The name and email must match `git config user.name` / `git config user.email`.
+
+If you forgot `-s` on an existing commit, fix it with one of:
+
+```bash
+# most recent commit
+git commit --amend --signoff --no-edit
+
+# every commit on the current branch
+git rebase --signoff origin/main
+```
+
+A DCO check runs automatically on every PR opened in the `getaxonflow` org. **PRs with any unsigned commit will be blocked from merging until the missing sign-offs are added.** No exceptions, including for maintainers.
+
 ## Development setup
 
 ```bash


### PR DESCRIPTION
Add the same DCO sign-off requirement section that landed in the Rust SDK pilot at getaxonflow/axonflow-sdk-rust#1.

The DCO GitHub App is already installed at the org level (covers all repos including future ones). This PR documents the expectation in CONTRIBUTING.md so contributors know what's required and how to fix unsigned commits.

## Diff scope

`CONTRIBUTING.md`: adds one new `## Sign your commits` section right before the first existing `##` heading.

## Test plan

- [ ] All CI checks green
- [ ] DCO check itself passes on this PR (commit signed via `git commit -s`)