### PR TITLE
chore(release): v7.7.0 — X-Axonflow-Client header [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to the AxonFlow Java SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.7.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation
+
+**Companion release to platform v7.7.0.** The Java SDK now sends an
+`X-Axonflow-Client` identification header on every governed request, which
+the agent uses to derive the SDK request scope and validate it against any
+license token's audience claim per the ADR-050 license matrix.
+
+### Added
+
+- **`X-Axonflow-Client: sdk-java/<version>` header** on every governed
+  outbound request. Set automatically by the SDK transport; not
+  configurable. Agents at v7.7.0+ derive request scope from this header
+  and reject cross-quadrant token misuse (e.g. a SaaS Plugin Pro token
+  paired with an SDK request) at the validator boundary. Older agents
+  (pre-v7.7.0) ignore the header and continue to work unchanged.
+
+### Compatibility
+
+- **No public API changes.** Existing v7.0.x callers update
+  `<version>7.7.0</version>` on the `axonflow-sdk` dependency and
+  rebuild against v7.7.0 with no source changes.
+- **Backward-compatible against pre-v7.7.0 agents.** The header is
+  silently dropped by older agents; the SDK behaves identically against
+  v7.0.x / v7.1.x / v7.6.x agents as before.
+- **Forward-compatible.** Future agent releases that require the header
+  on specific governed surfaces will work with this SDK without further
+  client changes.
+
+### Companion releases (same day)
+
+- **Platform v7.7.0** — V1 SaaS Plugin Pro launch, license matrix,
+  per-tenant tier resolution, GDPR right-to-erasure
+  ([CHANGELOG](https://github.com/getaxonflow/axonflow/blob/main/CHANGELOG.md))
+- **Go SDK v7.7.0** / **Python SDK v7.7.0** /
+  **TypeScript SDK v7.7.0** — same `X-Axonflow-Client` injection
+- **Plugins** — Claude Code / Cursor / Codex v1.2.0; OpenClaw v2.2.0
+  with Pro license token paste activating Pro features
+
+axonflow-sdk-rust remains at v0.1.0 (preview); SDK-Rust will gain the
+header in a future preview release.
+
 ## [7.0.0] - 2026-04-29 — Production, quality, and security hardening — upgrade encouraged
 
 **Upgrade strongly recommended.** Over the past month we've shipped substantial production, quality, and security hardening across the AxonFlow SDKs and platform — upgrade to the latest major for a more secure, reliable, and bug-free experience.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.getaxonflow</groupId>
     <artifactId>axonflow-sdk</artifactId>
-    <version>7.0.0</version>
+    <version>7.7.0</version>
     <packaging>jar</packaging>
 
     <name>AxonFlow Java SDK</name>


### PR DESCRIPTION
Companion release to **platform v7.7.0** (V1 SaaS Plugin Pro launch). The Java SDK gains the `X-Axonflow-Client: sdk-java/<version>` header on every governed request.

Single substantive change since v7.0.0: #161 (header injection). Other commits (#160 DCO docs, #162 definition-of-done CI gate, #158 v7.0.0 changelog typo) are infrastructure / docs.

## Compatibility
- **No public API changes** — bump `<version>` to 7.7.0 in your dependency block
- **Backward-compatible against pre-v7.7.0 agents**

## Self-review
- `pom.xml` 7.0.0 → 7.7.0; `SDK_VERSION` reads from Maven pom.properties at runtime so no Java source change needed
- CHANGELOG entry stamped 2026-05-06
- [skip-runtime-e2e]: version + CHANGELOG bump only

## Skip-runtime-e2e justification

This is a release-prep PR — version manifest bump + CHANGELOG promotion only. The substantive code changes (X-Axonflow-Client header injection for SDKs / V1 paid Pro tier wire-up for plugins) shipped in earlier feature PRs that included their own runtime-e2e tests against a live agent stack. Re-running runtime-e2e for a CHANGELOG and version-string change adds no signal — the runtime contract was validated when the feature commits landed.