### PR TITLE
fix(release): correct SDK version v7.7.0 → v7.1.0 [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow Java SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.7.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation
+## [7.1.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation
 
 **Companion release to platform v7.7.0.** The Java SDK now sends an
 `X-Axonflow-Client` identification header on every governed request, which
@@ -24,8 +24,8 @@ license token's audience claim per the ADR-050 license matrix.
 ### Compatibility
 
 - **No public API changes.** Existing v7.0.x callers update
-  `<version>7.7.0</version>` on the `axonflow-sdk` dependency and
-  rebuild against v7.7.0 with no source changes.
+  `<version>7.1.0</version>` on the `axonflow-sdk` dependency and
+  rebuild against v7.1.0 with no source changes.
 - **Backward-compatible against pre-v7.7.0 agents.** The header is
   silently dropped by older agents; the SDK behaves identically against
   v7.0.x / v7.1.x / v7.6.x agents as before.
@@ -38,8 +38,8 @@ license token's audience claim per the ADR-050 license matrix.
 - **Platform v7.7.0** — V1 SaaS Plugin Pro launch, license matrix,
   per-tenant tier resolution, GDPR right-to-erasure
   ([CHANGELOG](https://github.com/getaxonflow/axonflow/blob/main/CHANGELOG.md))
-- **Go SDK v7.7.0** / **Python SDK v7.7.0** /
-  **TypeScript SDK v7.7.0** — same `X-Axonflow-Client` injection
+- **Go SDK v7.1.0** / **Python SDK v7.1.0** /
+  **TypeScript SDK v7.1.0** — same `X-Axonflow-Client` injection
 - **Plugins** — Claude Code / Cursor / Codex v1.2.0; OpenClaw v2.2.0
   with Pro license token paste activating Pro features
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.getaxonflow</groupId>
     <artifactId>axonflow-sdk</artifactId>
-    <version>7.7.0</version>
+    <version>7.1.0</version>
     <packaging>jar</packaging>
 
     <name>AxonFlow Java SDK</name>


### PR DESCRIPTION
Companion to fixes axonflow-sdk-{go,python,typescript} #156 / #183 / #215. Previous release PR #163 bumped 7.0.0 → 7.7.0 (platform-align). Wrong semver — only one substantive feature since v7.0.0 (X-Axonflow-Client header injection #161), so natural bump is v7.1.0.

## Changes
- `pom.xml` <version> 7.7.0 → 7.1.0
- CHANGELOG header `[7.7.0]` → `[7.1.0]` (2026-05-06 preserved)
- Sister SDK refs (Go / Python / TypeScript) updated to v7.1.0
- Platform v7.7.0 refs kept (those are correctly the platform version)

## Skip-runtime-e2e justification

Version-correction only — no code behavior change. The X-Axonflow-Client header runtime contract was validated when #161 landed and re-confirmed when #163 merged. This PR only fixes the version string from the incorrect v7.7.0 to the semver-correct v7.1.0.