### PR TITLE
docs(telemetry): scope AXONFLOW_TELEMETRY=off to its actual data layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,10 @@ For enterprise features, contact [sales@getaxonflow.com](mailto:sales@getaxonflo
 This SDK sends anonymous usage telemetry (SDK version, OS, enabled features) to help improve AxonFlow.
 No prompts, payloads, or PII are ever collected. Opt out: `AXONFLOW_TELEMETRY=off`.
 
+### Scope of `AXONFLOW_TELEMETRY=off`
+
+`AXONFLOW_TELEMETRY=off` disables the anonymous SDK heartbeat (version, OS, architecture). On **self-hosted** and **in-VPC** deployments, that heartbeat is the only data the SDK sends to AxonFlow, so setting `=off` means we receive nothing. On **Community SaaS** (`try.getaxonflow.com`) the hosted service also processes operational data — registrations, audit logs, policy enforcement records, workflow state, plan data, and request-header metadata aggregated for usage analytics — as part of running the platform; that operational data flow is governed by the [Privacy Policy](https://getaxonflow.com/privacy/), not by `AXONFLOW_TELEMETRY`.
+
 `DO_NOT_TRACK` is **not** honored as an opt-out for AxonFlow telemetry. It is commonly inherited from host tools and developer environments, which makes it an unreliable expression of user intent.
 
 See [Telemetry Documentation](https://docs.getaxonflow.com/docs/telemetry) for full details.


### PR DESCRIPTION
## Summary
Adds a "Scope of \`AXONFLOW_TELEMETRY=off\`" subsection.

## Coordinated rollout
Same canonical wording across 11 repos as separate PRs.

## Test plan
- [x] Self-reviewed every hunk per HARD RULE #1 — single hunk, URLs valid, customer-shippable copy.
- README markdown only.

## NOT MERGE — user review pending