### PR TITLE
docs(examples): add explain-decision example [skip-runtime-e2e]

### DIFF
--- a/examples/explain-decision/pom.xml
+++ b/examples/explain-decision/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.getaxonflow.examples</groupId>
+    <artifactId>explain-decision</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>AxonFlow Java SDK — Explain Decision Example</name>
+    <description>
+        Runnable example for the ADR-043 explainability flow. Given a
+        decision_id from a recent blocked call, fetches the structured
+        DecisionExplanation and prints every field. Run with mvn install
+        on the SDK first to put the local artifact on the classpath.
+    </description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.getaxonflow</groupId>
+            <artifactId>axonflow-sdk</artifactId>
+            <version>7.1.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.getaxonflow.examples.ExplainDecision</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/explain-decision/src/main/java/com/getaxonflow/examples/ExplainDecision.java
+++ b/examples/explain-decision/src/main/java/com/getaxonflow/examples/ExplainDecision.java
@@ -1,0 +1,109 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: Apache-2.0
+//
+// AxonFlow Java SDK — explain a previously-made policy decision.
+//
+// Implements the ADR-043 explainability flow. Given a decision_id (typically
+// surfaced on the response of a blocked governed call, an audit_logs row, or
+// the `explain_decision` MCP tool), this example fetches the structured
+// explanation and renders the matched policies, risk level, and override
+// availability.
+//
+// Required env vars:
+//   AXONFLOW_AGENT_URL       (default: http://localhost:8080)
+//   AXONFLOW_CLIENT_ID       (default: community)
+//   AXONFLOW_CLIENT_SECRET   (default: empty)
+//   AXONFLOW_DECISION_ID     the decision to explain
+//
+// Run from this directory after `mvn install -DskipTests` at the SDK root:
+//
+//   mvn -q compile exec:java
+package com.getaxonflow.examples;
+
+import com.getaxonflow.sdk.AxonFlow;
+import com.getaxonflow.sdk.AxonFlowConfig;
+import com.getaxonflow.sdk.types.DecisionExplanation;
+import com.getaxonflow.sdk.types.ExplainPolicy;
+import com.getaxonflow.sdk.types.ExplainRule;
+
+public class ExplainDecision {
+
+    public static void main(String[] args) {
+        String endpoint = envOrDefault("AXONFLOW_AGENT_URL", "http://localhost:8080");
+        String clientId = envOrDefault("AXONFLOW_CLIENT_ID", "community");
+        String clientSecret = envOrDefault("AXONFLOW_CLIENT_SECRET", "");
+        String decisionId = System.getenv("AXONFLOW_DECISION_ID");
+
+        if (decisionId == null || decisionId.isEmpty()) {
+            System.err.println(
+                    "AXONFLOW_DECISION_ID must be set "
+                            + "(a decision_id from a recent blocked call)");
+            System.exit(2);
+        }
+
+        System.out.println("Initializing AxonFlow client at " + endpoint + "...");
+        try (AxonFlow client =
+                AxonFlow.create(
+                        AxonFlowConfig.builder()
+                                .agentUrl(endpoint)
+                                .clientId(clientId)
+                                .clientSecret(clientSecret)
+                                .build())) {
+
+            System.out.println("Explaining decision " + decisionId + "...\n");
+            DecisionExplanation exp = client.explainDecision(decisionId);
+
+            System.out.println("=== Decision Explanation ===");
+            System.out.println("  decision_id: " + exp.getDecisionId());
+            System.out.println("  timestamp:   " + exp.getTimestamp());
+            System.out.println("  decision:    " + exp.getDecision());
+            System.out.println("  reason:      " + exp.getReason());
+            if (exp.getRiskLevel() != null && !exp.getRiskLevel().isEmpty()) {
+                System.out.println("  risk_level:  " + exp.getRiskLevel());
+            }
+            if (exp.getToolSignature() != null && !exp.getToolSignature().isEmpty()) {
+                System.out.println("  tool:        " + exp.getToolSignature());
+            }
+
+            System.out.printf("%n  policy_matches (%d):%n", exp.getPolicyMatches().size());
+            int i = 0;
+            for (ExplainPolicy m : exp.getPolicyMatches()) {
+                String name = m.getPolicyName() != null ? m.getPolicyName() : "(unnamed)";
+                String action = m.getAction() != null ? m.getAction() : "-";
+                String risk = m.getRiskLevel() != null ? m.getRiskLevel() : "-";
+                System.out.printf(
+                        "    [%d] %s (%s) — action=%s risk=%s allow_override=%b%n",
+                        i, m.getPolicyId(), name, action, risk, m.isAllowOverride());
+                i++;
+            }
+
+            if (exp.getMatchedRules() != null && !exp.getMatchedRules().isEmpty()) {
+                System.out.printf("%n  matched_rules (%d):%n", exp.getMatchedRules().size());
+                for (ExplainRule r : exp.getMatchedRules()) {
+                    String ruleId = r.getRuleId() != null ? r.getRuleId() : "(no rule id)";
+                    String matchedOn = r.getMatchedOn() != null ? r.getMatchedOn() : "-";
+                    System.out.printf(
+                            "    %s on %s: matched=%s%n", r.getPolicyId(), ruleId, matchedOn);
+                }
+            }
+
+            System.out.printf("%n  override_available:           %b%n",
+                    exp.isOverrideAvailable());
+            if (exp.getOverrideExistingId() != null && !exp.getOverrideExistingId().isEmpty()) {
+                System.out.println("  override_existing_id:         "
+                        + exp.getOverrideExistingId());
+            }
+            System.out.println("  historical_hit_count_session: "
+                    + exp.getHistoricalHitCountSession());
+            if (exp.getPolicySourceLink() != null && !exp.getPolicySourceLink().isEmpty()) {
+                System.out.println("  policy_source_link:           "
+                        + exp.getPolicySourceLink());
+            }
+        }
+    }
+
+    private static String envOrDefault(String key, String fallback) {
+        String v = System.getenv(key);
+        return (v == null || v.isEmpty()) ? fallback : v;
+    }
+}


### PR DESCRIPTION
Closes the example-parity gap: `axonflow.explainDecision(...)` shipped in April but no runnable example existed. Mirror the Rust SDK pattern (axonflow-sdk-rust#29 / commit `2360282`) so a caller can copy a complete demo without reading the SDK source.

## Scope

- New `examples/explain-decision/` with its own pom.xml (mirrors `examples/basic/` layout).
- Reads `AXONFLOW_DECISION_ID` from env, calls `client.explainDecision(...)`, prints every ADR-043 field.
- Defaults `AXONFLOW_CLIENT_ID` to `community`.

## Three-rule definition of done

**Rule 0 — Runtime proof.** Live run against the local community stack at `localhost:8080` (agent v7.7.0):

Step 1 — trigger a real decision via curl (yields `decision_id=7a4876eb-3fd5-4467-a412-b0b42833e165`).

Step 2:
```bash
cd examples/explain-decision
AXONFLOW_AGENT_URL=http://localhost:8080 \
AXONFLOW_CLIENT_ID=community \
AXONFLOW_CLIENT_SECRET="" \
AXONFLOW_DECISION_ID=7a4876eb-3fd5-4467-a412-b0b42833e165 \
mvn -q exec:java -Dexec.mainClass=com.getaxonflow.examples.ExplainDecision
```

Output:
```
Initializing AxonFlow client at http://localhost:8080...
Explaining decision 7a4876eb-3fd5-4467-a412-b0b42833e165...

=== Decision Explanation ===
  decision_id: 7a4876eb-3fd5-4467-a412-b0b42833e165
  timestamp:   2026-05-07T12:16:36.779420Z
  decision:    deny
  reason:      Detects DROP TABLE statement
  risk_level:  critical

  policy_matches (1):
    [0] sys_sqli_drop_table (DROP TABLE Statement) — action=- risk=critical allow_override=false

  override_available:           false
  historical_hit_count_session: 0
```

**Rule 1 — Self-review.** Hunk-by-hunk:
- Getter accesses match `DecisionExplanation.java`: `getDecisionId`, `getTimestamp`, `getDecision`, `getReason`, `getRiskLevel`, `getToolSignature`, `getPolicyMatches`, `getMatchedRules`, `isOverrideAvailable`, `getOverrideExistingId`, `getHistoricalHitCountSession`, `getPolicySourceLink`. ✓
- `ExplainPolicy` getters: `getPolicyId`, `getPolicyName`, `getAction`, `getRiskLevel`, `isAllowOverride`, `getPolicyDescription`. ✓
- `ExplainRule` getters: `getPolicyId`, `getRuleId`, `getRuleText`, `getMatchedOn`. ✓
- Optional fields guarded with null + isEmpty checks before printing. ✓
- `try-with-resources` on the client mirrors the `Basic` example so OkHttp dispatcher cleans up. ✓
- pom.xml depends on `axonflow-sdk:7.1.0` (current published version). ✓

**Rule 2 — No deferred bugs.** None found in path. The example builds + runs cleanly against the v7.7.0 platform.

## ⛔ Do not merge — V1.1 release window

Per the `feedback_v1_1_no_merge_during_release_window.md` guideline.

## Skip-runtime-e2e justification

This SDK PR is runtime-tested by the repo's existing `integration.yml` workflow, which brings up the AxonFlow community stack via docker compose and runs every example end-to-end against it. Adding a parallel `runtime-e2e/<feature>/` subdir would duplicate that flow without adding signal.

Manual runtime proof for this PR (live stack, command + wire dump) is captured in the PR body above. The community-stack integration.yml run on this branch is the automated equivalent.

Pattern matches the existing Rust SDK convention where examples double as runtime tests (axonflow-sdk-rust commit `2360282`).