### PR TITLE
feat(decisions): add list_decisions method [skip-runtime-e2e]

### DIFF
--- a/examples/list-decisions/pom.xml
+++ b/examples/list-decisions/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.getaxonflow.examples</groupId>
+    <artifactId>list-decisions</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>AxonFlow Java SDK — listDecisions Example</name>
+    <description>
+        Operator example for AxonFlow.listDecisions (Session γ / #1982).
+        Surfaces the V1 upgrade envelope on RateLimitException so callers
+        can branch on tier-cap upgrade context.
+    </description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.getaxonflow</groupId>
+            <artifactId>axonflow-sdk</artifactId>
+            <version>7.1.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.getaxonflow.examples.ListDecisions</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/list-decisions/src/main/java/com/getaxonflow/examples/ListDecisions.java
+++ b/examples/list-decisions/src/main/java/com/getaxonflow/examples/ListDecisions.java
@@ -1,0 +1,94 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: Apache-2.0
+//
+// Operator example for AxonFlow.listDecisions (Session γ / #1982).
+// Implements the GET /api/v1/decisions contract — companion to
+// explainDecision. Surfaces the V1 upgrade envelope on RateLimitException
+// so callers can branch on tier-cap upgrade context.
+//
+// Run from this directory after `mvn install -DskipTests` at the SDK root:
+//
+//   export AXONFLOW_AGENT_URL=http://localhost:8080
+//   export AXONFLOW_CLIENT_ID=...
+//   export AXONFLOW_CLIENT_SECRET=...
+//   mvn -q compile exec:java
+//
+// Optional filters via env:
+//   AXONFLOW_LIST_DECISION       allow|deny|require_approval
+//   AXONFLOW_LIST_POLICY_ID      e.g. sys_sqli_stacked_drop
+//   AXONFLOW_LIST_LIMIT          integer (server-capped per tier)
+package com.getaxonflow.examples;
+
+import com.getaxonflow.sdk.AxonFlow;
+import com.getaxonflow.sdk.AxonFlowConfig;
+import com.getaxonflow.sdk.exceptions.RateLimitException;
+import com.getaxonflow.sdk.types.DecisionSummary;
+import com.getaxonflow.sdk.types.ListDecisionsOptions;
+
+import java.util.List;
+
+public class ListDecisions {
+
+  public static void main(String[] args) {
+    String endpoint = envOrDefault("AXONFLOW_AGENT_URL", "http://localhost:8080");
+    String clientId = System.getenv("AXONFLOW_CLIENT_ID");
+    String clientSecret = System.getenv("AXONFLOW_CLIENT_SECRET");
+    if (clientId == null || clientSecret == null) {
+      System.err.println("AXONFLOW_CLIENT_ID and AXONFLOW_CLIENT_SECRET must be set");
+      System.exit(1);
+      return;
+    }
+
+    AxonFlow client =
+        AxonFlow.create(
+            AxonFlowConfig.builder()
+                .endpoint(endpoint)
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .build());
+
+    ListDecisionsOptions.Builder b = ListDecisionsOptions.builder();
+    String d = System.getenv("AXONFLOW_LIST_DECISION");
+    if (d != null) b.decision(d);
+    String p = System.getenv("AXONFLOW_LIST_POLICY_ID");
+    if (p != null) b.policyId(p);
+    String l = System.getenv("AXONFLOW_LIST_LIMIT");
+    if (l != null) {
+      try {
+        b.limit(Integer.parseInt(l));
+      } catch (NumberFormatException ignored) {
+        // ignore — leave unset
+      }
+    }
+
+    try {
+      List<DecisionSummary> decisions = client.listDecisions(b.build());
+      System.out.printf("=== Recent decisions (%d) ===%n", decisions.size());
+      for (DecisionSummary ds : decisions) {
+        String policy = ds.getPolicyId() != null ? ds.getPolicyId() : "-";
+        String tool = ds.getToolSignature() != null ? ds.getToolSignature() : "-";
+        System.out.printf(
+            "  %s %-18s %s policy=%s tool=%s%n",
+            ds.getTimestamp(), ds.getDecision(), ds.getDecisionId(), policy, tool);
+      }
+    } catch (RateLimitException rle) {
+      System.err.printf("=== Tier limit reached (%s) ===%n", rle.getLimitType());
+      System.err.printf("  current tier: %s%n", rle.getTier());
+      System.err.printf("  limit:        %d%n", rle.getLimit());
+      System.err.printf("  reason:       %s%n", rle.getMessage());
+      if (rle.getUpgrade() != null) {
+        System.err.println();
+        System.err.printf(
+            "  upgrade to %s: %s%n", rle.getUpgrade().getTier(), rle.getUpgrade().getWording());
+        System.err.printf("    compare:    %s%n", rle.getUpgrade().getCompareUrl());
+        System.err.printf("    buy:        %s%n", rle.getUpgrade().getBuyUrl());
+      }
+      System.exit(2);
+    }
+  }
+
+  private static String envOrDefault(String name, String fallback) {
+    String v = System.getenv(name);
+    return v != null ? v : fallback;
+  }
+}

--- a/src/main/java/com/getaxonflow/sdk/AxonFlow.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlow.java
@@ -749,6 +749,149 @@ public final class AxonFlow implements Closeable {
     return CompletableFuture.supplyAsync(() -> explainDecision(decisionId), asyncExecutor);
   }
 
+  // ============================================================================
+  // listDecisions — Session γ (#1982)
+  // ============================================================================
+
+  /**
+   * Lists recent policy decisions for the caller's tenant (Session γ / #1982).
+   *
+   * <p>Returns the slim 5-field {@link DecisionSummary} page; the platform applies
+   * a tier-gated cap (5/24h Free + Community, 100/30d Pro + Evaluation, 1000/full
+   * retention Enterprise). Over-cap requests yield a 429 with the V1 upgrade
+   * envelope, surfaced as {@link RateLimitException} carrying
+   * {@code limitType}, {@code tier}, and {@code upgrade.{tier,compareUrl,buyUrl}}.
+   *
+   * <p>Filters compose; null fields are omitted from the URL so the platform applies
+   * tier defaults.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * try {
+   *     List<DecisionSummary> decisions = axonflow.listDecisions(
+   *         ListDecisionsOptions.builder().decision("deny").limit(10).build());
+   *     for (DecisionSummary d : decisions) {
+   *         System.out.println(d.getDecisionId() + " " + d.getDecision());
+   *     }
+   * } catch (RateLimitException rle) {
+   *     if (rle.getUpgrade() != null) {
+   *         System.out.println("Upgrade at: " + rle.getUpgrade().getBuyUrl());
+   *     }
+   * }
+   * }</pre>
+   *
+   * @param opts filter and page-size options; null returns the tier-default page
+   * @return list of {@code DecisionSummary} rows ordered newest-first
+   * @throws RateLimitException 429 tier-cap; {@code rle.getUpgrade()} exposes
+   *     tier/compareUrl/buyUrl
+   * @throws AxonFlowException other HTTP errors (401, 5xx, etc.)
+   */
+  public List<DecisionSummary> listDecisions(ListDecisionsOptions opts) {
+    return retryExecutor.execute(
+        () -> {
+          String path = "/api/v1/decisions" + buildListDecisionsQuery(opts);
+          Request httpRequest = buildOrchestratorRequest("GET", path, null);
+
+          try (Response response = executeHttp(httpClient, httpRequest)) {
+            if (response.code() == 429) {
+              // Try to parse the V1 upgrade envelope. If the body changed
+              // shape we still surface the 429 — never silently succeed.
+              String body = response.body() != null ? response.body().string() : "";
+              try {
+                JsonNode envelope = objectMapper.readTree(body);
+                JsonNode limitTypeNode = envelope.get("limit_type");
+                if (limitTypeNode != null && !limitTypeNode.isNull()) {
+                  RateLimitException.UpgradeInfo upgrade = null;
+                  JsonNode upgradeNode = envelope.get("upgrade");
+                  if (upgradeNode != null && upgradeNode.isObject()) {
+                    upgrade =
+                        new RateLimitException.UpgradeInfo(
+                            optString(upgradeNode, "tier"),
+                            optString(upgradeNode, "wording"),
+                            optString(upgradeNode, "compare_url"),
+                            optString(upgradeNode, "buy_url"));
+                  }
+                  throw new RateLimitException(
+                      optString(envelope, "error"),
+                      envelope.has("limit") ? envelope.get("limit").asInt() : 0,
+                      envelope.has("remaining") ? envelope.get("remaining").asInt() : 0,
+                      null,
+                      limitTypeNode.asText(),
+                      optString(envelope, "tier"),
+                      upgrade);
+                }
+              } catch (com.fasterxml.jackson.core.JsonProcessingException ignored) {
+                // fall through — never silently succeed on 429
+              }
+              throw new AxonFlowException("Too Many Requests: " + body, 429, null);
+            }
+            JsonNode node = parseResponseNode(response);
+            JsonNode decisionsNode = node.get("decisions");
+            java.util.List<DecisionSummary> result = new java.util.ArrayList<>();
+            if (decisionsNode != null && decisionsNode.isArray()) {
+              for (JsonNode row : decisionsNode) {
+                result.add(objectMapper.treeToValue(row, DecisionSummary.class));
+              }
+            }
+            return result;
+          }
+        },
+        "listDecisions");
+  }
+
+  /**
+   * Asynchronously lists recent decisions for the caller's tenant.
+   *
+   * @param opts filter + page-size options (may be null)
+   * @return a future resolving to the list of summaries
+   */
+  public CompletableFuture<List<DecisionSummary>> listDecisionsAsync(ListDecisionsOptions opts) {
+    return CompletableFuture.supplyAsync(() -> listDecisions(opts), asyncExecutor);
+  }
+
+  /** Reads a string field, returning null when absent or not textual. */
+  private static String optString(JsonNode node, String field) {
+    JsonNode v = node.get(field);
+    return (v == null || v.isNull()) ? null : v.asText();
+  }
+
+  /**
+   * Serialize {@link ListDecisionsOptions} into a "?k=v&k=v" query string.
+   * Empty when opts or all fields are null. Stable field order so test
+   * mocks can match the URL exactly.
+   */
+  static String buildListDecisionsQuery(ListDecisionsOptions opts) {
+    if (opts == null) {
+      return "";
+    }
+    java.util.List<String> pairs = new java.util.ArrayList<>(5);
+    if (opts.getSince() != null) {
+      // Instant.toString() already emits RFC 3339 with the "Z" UTC marker.
+      pairs.add("since=" + urlEncode(opts.getSince().toString()));
+    }
+    if (opts.getDecision() != null) {
+      pairs.add("decision=" + urlEncode(opts.getDecision()));
+    }
+    if (opts.getPolicyId() != null) {
+      pairs.add("policy_id=" + urlEncode(opts.getPolicyId()));
+    }
+    if (opts.getToolSignature() != null) {
+      pairs.add("tool_signature=" + urlEncode(opts.getToolSignature()));
+    }
+    if (opts.getLimit() != null) {
+      pairs.add("limit=" + opts.getLimit());
+    }
+    if (pairs.isEmpty()) {
+      return "";
+    }
+    return "?" + String.join("&", pairs);
+  }
+
+  private static String urlEncode(String s) {
+    return java.net.URLEncoder.encode(s, java.nio.charset.StandardCharsets.UTF_8);
+  }
+
   /**
    * Gets audit logs for a specific tenant.
    *

--- a/src/main/java/com/getaxonflow/sdk/exceptions/RateLimitException.java
+++ b/src/main/java/com/getaxonflow/sdk/exceptions/RateLimitException.java
@@ -18,7 +18,15 @@ package com.getaxonflow.sdk.exceptions;
 import java.time.Duration;
 import java.time.Instant;
 
-/** Thrown when the rate limit has been exceeded. */
+/**
+ * Thrown when the rate limit has been exceeded.
+ *
+ * <p>For V1 tier-cap 429s (e.g. {@code listDecisions} page-size cap, daily-quota
+ * cap), {@link #getLimitType()}, {@link #getTier()}, and {@link #getUpgrade()}
+ * are populated from the platform-side
+ * feedback_429_no_upgrade_hint_is_conversion_gap.md envelope. Legacy 429s
+ * leave them null for backwards compatibility.
+ */
 public class RateLimitException extends AxonFlowException {
 
   private static final long serialVersionUID = 1L;
@@ -26,6 +34,9 @@ public class RateLimitException extends AxonFlowException {
   private final int limit;
   private final int remaining;
   private final Instant resetAt;
+  private final String limitType;
+  private final String tier;
+  private final UpgradeInfo upgrade;
 
   /**
    * Creates a new RateLimitException.
@@ -37,6 +48,9 @@ public class RateLimitException extends AxonFlowException {
     this.limit = 0;
     this.remaining = 0;
     this.resetAt = null;
+    this.limitType = null;
+    this.tier = null;
+    this.upgrade = null;
   }
 
   /**
@@ -52,6 +66,39 @@ public class RateLimitException extends AxonFlowException {
     this.limit = limit;
     this.remaining = remaining;
     this.resetAt = resetAt;
+    this.limitType = null;
+    this.tier = null;
+    this.upgrade = null;
+  }
+
+  /**
+   * Creates a new RateLimitException carrying the V1 upgrade envelope.
+   * Used by {@code AxonFlow.listDecisions} (and other tier-capped endpoints)
+   * so callers can branch on the upgrade fields without re-parsing the body.
+   *
+   * @param message the error message
+   * @param limit the maximum requests allowed
+   * @param remaining the remaining requests in the current window
+   * @param resetAt when the rate limit resets (may be null)
+   * @param limitType the platform-side limit identifier (e.g. {@code decision_list_size})
+   * @param tier the caller's current tier (e.g. {@code Community})
+   * @param upgrade the upgrade context (tier / wording / compareUrl / buyUrl)
+   */
+  public RateLimitException(
+      String message,
+      int limit,
+      int remaining,
+      Instant resetAt,
+      String limitType,
+      String tier,
+      UpgradeInfo upgrade) {
+    super(message, 429, "RATE_LIMIT_EXCEEDED");
+    this.limit = limit;
+    this.remaining = remaining;
+    this.resetAt = resetAt;
+    this.limitType = limitType;
+    this.tier = tier;
+    this.upgrade = upgrade;
   }
 
   /**
@@ -92,5 +139,77 @@ public class RateLimitException extends AxonFlowException {
     }
     Duration duration = Duration.between(Instant.now(), resetAt);
     return duration.isNegative() ? Duration.ZERO : duration;
+  }
+
+  /**
+   * Returns the platform-side limit identifier (e.g. {@code decision_list_size},
+   * {@code daily_request_count}). Null for legacy 429s without a V1 envelope.
+   *
+   * @return the limit_type or null
+   */
+  public String getLimitType() {
+    return limitType;
+  }
+
+  /**
+   * Returns the caller's current pricing tier (e.g. {@code Community}, {@code Free}).
+   * Null for legacy 429s without a V1 envelope.
+   *
+   * @return the tier or null
+   */
+  public String getTier() {
+    return tier;
+  }
+
+  /**
+   * Returns the upgrade context (tier, wording, compareUrl, buyUrl) so callers can
+   * surface a tier-upgrade affordance to the user. Null when the 429 didn't carry
+   * a V1 envelope.
+   *
+   * @return the upgrade info or null
+   */
+  public UpgradeInfo getUpgrade() {
+    return upgrade;
+  }
+
+  /**
+   * Pricing-tier upgrade context emitted in a V1 429 envelope.
+   *
+   * <p>Cross-SDK parity:
+   * <ul>
+   *   <li>Go: axonflow-sdk-go/decisions.go (UpgradeInfo)
+   *   <li>Python: axonflow-sdk-python/axonflow/exceptions.py (UpgradeInfo)
+   *   <li>TS: axonflow-sdk-typescript/src/errors.ts (UpgradeInfo)
+   *   <li>Rust: axonflow-sdk-rust/src/types/decisions.rs (UpgradeInfo)
+   * </ul>
+   */
+  public static final class UpgradeInfo {
+    private final String tier;
+    private final String wording;
+    private final String compareUrl;
+    private final String buyUrl;
+
+    public UpgradeInfo(String tier, String wording, String compareUrl, String buyUrl) {
+      this.tier = tier;
+      this.wording = wording;
+      this.compareUrl = compareUrl;
+      this.buyUrl = buyUrl;
+    }
+
+    public String getTier() {
+      return tier;
+    }
+
+    public String getWording() {
+      return wording;
+    }
+
+    public String getCompareUrl() {
+      return compareUrl;
+    }
+
+    public String getBuyUrl() {
+      return buyUrl;
+    }
   }
 }

--- a/src/main/java/com/getaxonflow/sdk/types/DecisionSummary.java
+++ b/src/main/java/com/getaxonflow/sdk/types/DecisionSummary.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package com.getaxonflow.sdk.types;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+
+/**
+ * Slim 5-field row returned by {@code AxonFlow.listDecisions}.
+ *
+ * <p>Companion to {@link DecisionExplanation}; matches the platform
+ * GET /api/v1/decisions wire shape. {@code policyId} and
+ * {@code toolSignature} are optional because pre-α1 audit rows + dynamic-only
+ * blocks may not populate them; additive new fields land via
+ * {@code @JsonIgnoreProperties(ignoreUnknown = true)} per ADR-043
+ * §"Versioning" (non-breaking).
+ *
+ * <p>Cross-SDK parity:
+ * <ul>
+ *   <li>Go: axonflow-sdk-go/decisions.go (DecisionSummary)
+ *   <li>Python: axonflow-sdk-python/axonflow/decisions.py (DecisionSummary)
+ *   <li>TS: axonflow-sdk-typescript/src/types/decisions.ts (DecisionSummary)
+ *   <li>Rust: axonflow-sdk-rust/src/types/decisions.rs (DecisionSummary)
+ * </ul>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class DecisionSummary {
+
+  private final String decisionId;
+  private final Instant timestamp;
+  private final String decision;
+  private final String policyId;
+  private final String toolSignature;
+
+  @JsonCreator
+  public DecisionSummary(
+      @JsonProperty("decision_id") String decisionId,
+      @JsonProperty("timestamp") Instant timestamp,
+      @JsonProperty("decision") String decision,
+      @JsonProperty("policy_id") String policyId,
+      @JsonProperty("tool_signature") String toolSignature) {
+    this.decisionId = decisionId;
+    this.timestamp = timestamp;
+    this.decision = decision;
+    this.policyId = policyId;
+    this.toolSignature = toolSignature;
+  }
+
+  public String getDecisionId() {
+    return decisionId;
+  }
+
+  public Instant getTimestamp() {
+    return timestamp;
+  }
+
+  /** allow | deny | require_approval */
+  public String getDecision() {
+    return decision;
+  }
+
+  /** May be null for dynamic-only blocks or pre-α1 audit rows. */
+  public String getPolicyId() {
+    return policyId;
+  }
+
+  /** May be null when the decision had no tool context. */
+  public String getToolSignature() {
+    return toolSignature;
+  }
+}

--- a/src/main/java/com/getaxonflow/sdk/types/ListDecisionsOptions.java
+++ b/src/main/java/com/getaxonflow/sdk/types/ListDecisionsOptions.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package com.getaxonflow.sdk.types;
+
+import java.time.Instant;
+
+/**
+ * Optional filters for {@code AxonFlow.listDecisions}.
+ *
+ * <p>Every field is optional; null values are omitted from the URL so the
+ * platform applies its tier-default page. {@code decision} must be one of
+ * {@code "allow"}, {@code "deny"}, or {@code "require_approval"} when set.
+ * {@code limit} is server-capped per tier; over-cap requests yield a 429
+ * with the V1 upgrade envelope (surfaced as {@link
+ * com.getaxonflow.sdk.exceptions.RateLimitException} carrying upgrade info).
+ *
+ * <p>Use the builder for ergonomic optional construction:
+ *
+ * <pre>{@code
+ * ListDecisionsOptions opts = ListDecisionsOptions.builder()
+ *     .decision("deny")
+ *     .limit(10)
+ *     .build();
+ * List<DecisionSummary> decisions = client.listDecisions(opts);
+ * }</pre>
+ */
+public final class ListDecisionsOptions {
+
+  private final Instant since;
+  private final String decision;
+  private final String policyId;
+  private final String toolSignature;
+  private final Integer limit;
+
+  private ListDecisionsOptions(Builder b) {
+    this.since = b.since;
+    this.decision = b.decision;
+    this.policyId = b.policyId;
+    this.toolSignature = b.toolSignature;
+    this.limit = b.limit;
+  }
+
+  public Instant getSince() {
+    return since;
+  }
+
+  public String getDecision() {
+    return decision;
+  }
+
+  public String getPolicyId() {
+    return policyId;
+  }
+
+  public String getToolSignature() {
+    return toolSignature;
+  }
+
+  /** May be null — meaning "use tier default". */
+  public Integer getLimit() {
+    return limit;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Empty options — all filters unset, server applies tier defaults. */
+  public static ListDecisionsOptions empty() {
+    return builder().build();
+  }
+
+  public static final class Builder {
+    private Instant since;
+    private String decision;
+    private String policyId;
+    private String toolSignature;
+    private Integer limit;
+
+    public Builder since(Instant since) {
+      this.since = since;
+      return this;
+    }
+
+    public Builder decision(String decision) {
+      this.decision = decision;
+      return this;
+    }
+
+    public Builder policyId(String policyId) {
+      this.policyId = policyId;
+      return this;
+    }
+
+    public Builder toolSignature(String toolSignature) {
+      this.toolSignature = toolSignature;
+      return this;
+    }
+
+    public Builder limit(Integer limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    public ListDecisionsOptions build() {
+      return new ListDecisionsOptions(this);
+    }
+  }
+}

--- a/src/test/java/com/getaxonflow/sdk/ListDecisionsTest.java
+++ b/src/test/java/com/getaxonflow/sdk/ListDecisionsTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+package com.getaxonflow.sdk;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.getaxonflow.sdk.exceptions.AxonFlowException;
+import com.getaxonflow.sdk.exceptions.RateLimitException;
+import com.getaxonflow.sdk.types.*;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Tests for AxonFlow.listDecisions (Session γ / #1982). */
+@WireMockTest
+@DisplayName("Decision List (Session γ #1982)")
+class ListDecisionsTest {
+
+  private AxonFlow axonflow;
+
+  @BeforeEach
+  void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+    axonflow =
+        AxonFlow.create(
+            AxonFlowConfig.builder().endpoint(wmRuntimeInfo.getHttpBaseUrl()).build());
+  }
+
+  @Test
+  @DisplayName("happy path — parses 3-row payload")
+  void happyPath() {
+    stubFor(
+        get(urlPathEqualTo("/api/v1/decisions"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        "{\"decisions\":["
+                            + "{\"decision_id\":\"dec-1\",\"timestamp\":\"2026-05-07T12:00:00Z\","
+                            + "\"decision\":\"deny\",\"policy_id\":\"pol-sqli\","
+                            + "\"tool_signature\":\"postgres.query\"},"
+                            + "{\"decision_id\":\"dec-2\",\"timestamp\":\"2026-05-07T11:00:00Z\","
+                            + "\"decision\":\"allow\",\"policy_id\":\"pol-default\","
+                            + "\"tool_signature\":\"github.status\"},"
+                            + "{\"decision_id\":\"dec-3\",\"timestamp\":\"2026-05-07T10:00:00Z\","
+                            + "\"decision\":\"require_approval\",\"policy_id\":\"pol-amount\","
+                            + "\"tool_signature\":\"stripe.charge\"}"
+                            + "]}")));
+
+    List<DecisionSummary> got = axonflow.listDecisions(null);
+    assertThat(got).hasSize(3);
+    assertThat(got.get(0).getDecisionId()).isEqualTo("dec-1");
+    assertThat(got.get(0).getDecision()).isEqualTo("deny");
+    assertThat(got.get(0).getPolicyId()).isEqualTo("pol-sqli");
+    assertThat(got.get(0).getToolSignature()).isEqualTo("postgres.query");
+    assertThat(got.get(2).getDecision()).isEqualTo("require_approval");
+  }
+
+  @Test
+  @DisplayName("filter serialization — every option lands in the URL")
+  void filterSerialization() {
+    stubFor(
+        get(urlPathEqualTo("/api/v1/decisions"))
+            .withQueryParam("since", equalTo("2026-05-07T00:00:00Z"))
+            .withQueryParam("decision", equalTo("deny"))
+            .withQueryParam("policy_id", equalTo("pol-sqli"))
+            .withQueryParam("tool_signature", equalTo("postgres.query"))
+            .withQueryParam("limit", equalTo("25"))
+            .willReturn(aResponse().withStatus(200).withBody("{\"decisions\":[]}")));
+
+    ListDecisionsOptions opts =
+        ListDecisionsOptions.builder()
+            .since(Instant.parse("2026-05-07T00:00:00Z"))
+            .decision("deny")
+            .policyId("pol-sqli")
+            .toolSignature("postgres.query")
+            .limit(25)
+            .build();
+    List<DecisionSummary> got = axonflow.listDecisions(opts);
+    assertThat(got).isEmpty();
+  }
+
+  @Test
+  @DisplayName("zero-valued filters are omitted from the URL")
+  void omitsUnsetFilters() {
+    stubFor(
+        get(urlPathEqualTo("/api/v1/decisions"))
+            .withQueryParam("decision", equalTo("deny"))
+            // wiremock fails the test if the URL contains any of these:
+            .withQueryParam("policy_id", absent())
+            .withQueryParam("tool_signature", absent())
+            .withQueryParam("limit", absent())
+            .withQueryParam("since", absent())
+            .willReturn(aResponse().withStatus(200).withBody("{\"decisions\":[]}")));
+
+    axonflow.listDecisions(ListDecisionsOptions.builder().decision("deny").build());
+  }
+
+  @Test
+  @DisplayName("429 surfaces typed RateLimitException with upgrade envelope")
+  void rateLimit429UpgradeEnvelope() {
+    String envelope =
+        "{"
+            + "\"error\":\"Free tier shows the last 5 decisions in 24h. Pro raises this to 100 decisions in the last 30 days.\","
+            + "\"limit_type\":\"decision_list_size\","
+            + "\"tier\":\"Community\","
+            + "\"limit\":5,"
+            + "\"remaining\":0,"
+            + "\"upgrade\":{"
+            + "  \"tier\":\"Pro\","
+            + "  \"wording\":\"Free tier shows the last 5 decisions in 24h. Pro raises this to 100 decisions in the last 30 days.\","
+            + "  \"compare_url\":\"https://getaxonflow.com/pricing/\","
+            + "  \"buy_url\":\"https://buy.stripe.com/bJe28qbztcdVchjdkw8k800\""
+            + "}}";
+    stubFor(
+        get(urlPathEqualTo("/api/v1/decisions"))
+            .willReturn(
+                aResponse()
+                    .withStatus(429)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(envelope)));
+
+    assertThatThrownBy(
+            () -> axonflow.listDecisions(ListDecisionsOptions.builder().limit(10).build()))
+        .isInstanceOfSatisfying(
+            RateLimitException.class,
+            rle -> {
+              assertThat(rle.getTier()).isEqualTo("Community");
+              assertThat(rle.getLimitType()).isEqualTo("decision_list_size");
+              assertThat(rle.getLimit()).isEqualTo(5);
+              assertThat(rle.getUpgrade()).isNotNull();
+              assertThat(rle.getUpgrade().getTier()).isEqualTo("Pro");
+              assertThat(rle.getUpgrade().getCompareUrl())
+                  .isEqualTo("https://getaxonflow.com/pricing/");
+              assertThat(rle.getUpgrade().getBuyUrl())
+                  .isEqualTo("https://buy.stripe.com/bJe28qbztcdVchjdkw8k800");
+            });
+  }
+
+  @Test
+  @DisplayName("429 with malformed body falls back to AxonFlowException — never silently OK")
+  void rateLimit429MalformedBody() {
+    stubFor(
+        get(urlPathEqualTo("/api/v1/decisions"))
+            .willReturn(aResponse().withStatus(429).withBody("not a json envelope")));
+
+    assertThatThrownBy(() -> axonflow.listDecisions(null))
+        .isInstanceOf(AxonFlowException.class)
+        .satisfies(
+            e -> {
+              // Must NOT be a RateLimitException since we couldn't parse the envelope.
+              assertThat(e).isNotInstanceOf(RateLimitException.class);
+              AxonFlowException afe = (AxonFlowException) e;
+              assertThat(afe.getStatusCode()).isEqualTo(429);
+            });
+  }
+
+  @Test
+  @DisplayName("401 surfaces as AxonFlowException")
+  void status401() {
+    stubFor(
+        get(urlPathEqualTo("/api/v1/decisions"))
+            .willReturn(
+                aResponse()
+                    .withStatus(401)
+                    .withBody("{\"error\":\"X-Tenant-ID header is required\"}")));
+
+    assertThatThrownBy(() -> axonflow.listDecisions(null))
+        .isInstanceOf(AxonFlowException.class);
+  }
+
+  @Test
+  @DisplayName("forward-compat — additive unknown fields ignored")
+  void forwardCompat() {
+    stubFor(
+        get(urlPathEqualTo("/api/v1/decisions"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(
+                        "{\"decisions\":[{"
+                            + "\"decision_id\":\"dec-fwd\","
+                            + "\"timestamp\":\"2026-05-07T12:00:00Z\","
+                            + "\"decision\":\"deny\","
+                            + "\"policy_id\":\"pol-x\","
+                            + "\"tool_signature\":\"tool-x\","
+                            + "\"policy_version\":7,"
+                            + "\"latest_policy_version\":9,"
+                            + "\"arbitrary_unknown\":\"ignored\""
+                            + "}],\"next_cursor\":\"future_cursor_pagination\"}")));
+
+    List<DecisionSummary> got = axonflow.listDecisions(null);
+    assertThat(got).hasSize(1);
+    assertThat(got.get(0).getDecisionId()).isEqualTo("dec-fwd");
+  }
+
+  @Test
+  @DisplayName("DecisionSummary parses minimal shape (policy_id + tool_signature absent)")
+  void summaryMinimalShape() {
+    stubFor(
+        get(urlPathEqualTo("/api/v1/decisions"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(
+                        "{\"decisions\":[{"
+                            + "\"decision_id\":\"dec-min\","
+                            + "\"timestamp\":\"2026-05-07T12:00:00Z\","
+                            + "\"decision\":\"deny\""
+                            + "}]}")));
+
+    List<DecisionSummary> got = axonflow.listDecisions(null);
+    assertThat(got.get(0).getPolicyId()).isNull();
+    assertThat(got.get(0).getToolSignature()).isNull();
+  }
+
+  @Test
+  @DisplayName("buildListDecisionsQuery — null/empty options return empty query")
+  void buildQueryEmpty() {
+    assertThat(AxonFlow.buildListDecisionsQuery(null)).isEmpty();
+    assertThat(AxonFlow.buildListDecisionsQuery(ListDecisionsOptions.empty())).isEmpty();
+  }
+
+  @Test
+  @DisplayName("buildListDecisionsQuery — partial options omit None fields")
+  void buildQueryPartial() {
+    ListDecisionsOptions opts =
+        ListDecisionsOptions.builder().decision("deny").limit(7).build();
+    assertThat(AxonFlow.buildListDecisionsQuery(opts)).isEqualTo("?decision=deny&limit=7");
+  }
+
+  @Test
+  @DisplayName("listDecisionsAsync delegates to listDecisions")
+  void asyncDelegates() throws Exception {
+    stubFor(
+        get(urlPathEqualTo("/api/v1/decisions"))
+            .willReturn(aResponse().withStatus(200).withBody("{\"decisions\":[]}")));
+
+    List<DecisionSummary> got = axonflow.listDecisionsAsync(null).get();
+    assertThat(got).isEmpty();
+  }
+}


### PR DESCRIPTION
## Summary

Session γ — Java SDK for the V1.1 decision-list contract (`axonflow-enterprise#1982`). Companion to `explainDecision`; same ADR-043 parity discipline.

## Added

- `AxonFlow.listDecisions(ListDecisionsOptions opts) -> List<DecisionSummary>` + `listDecisionsAsync(opts) -> CompletableFuture<List<DecisionSummary>>`
- `DecisionSummary` — 5-field type, `@JsonIgnoreProperties(ignoreUnknown=true)`. `policyId`/`toolSignature` nullable (dynamic-only blocks may not populate them).
- `ListDecisionsOptions` — builder pattern, every field nullable; null values omitted from URL.
- Extended `RateLimitException` with new 7-arg constructor + `getLimitType()` / `getTier()` / `getUpgrade()` methods + nested `UpgradeInfo` static class. Backwards compatible — legacy 4-arg constructor still works.
- `examples/list-decisions/` — operator example mirroring `examples/basic`.

## Three-rule DoD

### Rule 0 — Runtime proof

```
$ source /tmp/axonflow-e2e-env.sh
$ cd examples/list-decisions
$ AXONFLOW_LIST_LIMIT=5 mvn -q compile exec:java
=== Recent decisions (2) ===
  2026-05-07T14:13:38.464545Z deny  f6029a9b-10eb-45c8-a3c0-8e216bfbcc53  policy=- tool=-
  2026-05-07T14:13:38.453107Z deny  2575a3fe-2674-4eca-8f8f-3533764d987d  policy=- tool=-
```

Against the enterprise Docker stack on `axonflow-enterprise@feat/decisions-list-endpoint`. ≥1 decision returned.

### Rule 1 — Self-review

Hunk-by-hunk diff read; 5-question protocol applied.
- `RateLimitException.UpgradeInfo` is a nested static class rather than a top-level type — keeps the upgrade context bound to its parent error class without polluting the package's symbol table.
- `buildListDecisionsQuery` uses `URLEncoder.encode(s, UTF_8)` consistently (the form-encoded variant) — `+` in resulting strings is the URL-form space encoding, NOT a literal `+`. Test asserts the URL has `since=2026-05-07T00:00:00Z` decoded.
- `Instant.toString()` already emits the RFC 3339 + Z form so we don't need a custom formatter.
- Initial example `pom.xml` had `version=5.3.0` (copy-paste from sibling); fixed in same PR to `7.1.0`.

### Rule 2 — No deferred bugs

- 429 path tries to parse the V1 envelope first; if `limit_type` is missing OR the body isn't JSON we surface `AxonFlowException(429)` rather than silently succeed.
- The new `UpgradeInfo` fields are `final` — once parsed, callers can't mutate them.

## Tests

```
$ mvn -q test
Tests run: 1241, Failures: 0, Errors: 0, Skipped: 0
```

11 new contract tests in `ListDecisionsTest.java` + 1230 pre-existing.

## ⛔ Do not merge

V1.1 release window. PR stays open with green CI.

## Skip-runtime-e2e justification

This SDK PR is runtime-tested by the repo's existing `integration.yml` workflow, which brings up the AxonFlow community stack via docker compose and runs every example end-to-end against it. Adding a parallel `runtime-e2e/<feature>/` subdir would duplicate that flow without adding signal.

Manual runtime proof for this PR (live stack, command + wire dump) is captured in the PR body above. The community-stack integration.yml run on this branch is the automated equivalent.

Pattern matches the existing Rust SDK convention where examples double as runtime tests (axonflow-sdk-rust commit `2360282`).