### PR TITLE
docs(changelog): scrub profile-field noise [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,6 @@ All notable changes to the AxonFlow Java SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [8.0.1] - 2026-05-08 — Drop telemetry `profile` field
-
-### Removed
-
-- **Telemetry `profile` field** — collided with existing governance
-  `AXONFLOW_PROFILE` env var (allowlist `dev|default|strict|compliance`).
-  The v1 telemetry validator only accepted `dev|prod|unknown`, so any
-  customer setting `AXONFLOW_PROFILE=strict` or `=compliance` for
-  governance enforcement would have had their telemetry pings rejected
-  with HTTP 400. Removing the field reverts `AXONFLOW_PROFILE` to its
-  single governance purpose. The `deployment_mode` dimension already
-  carries the topology signal `profile` was meant to add.
-
 ## [8.0.0] - 2026-05-08 — Decision history API + telemetry simplification
 
 **Major release.** The headline feature is the new decision-history client
@@ -75,7 +62,7 @@ contract — see `Removed` at the bottom of this entry for that.
 
 ### Telemetry payload (v1 schema, axonflow-enterprise#2008)
 
-- New heartbeat fields: `telemetry_type: "sdk"`, `profile` (from `AXONFLOW_PROFILE`, `unknown` when unset), `deployment_mode` aligned to `self_hosted | community_saas | unknown` via the new `classifyDeploymentMode` (host + `AXONFLOW_TRY=1` override). New `DeploymentMode` constants class.
+- New heartbeat fields: `telemetry_type: "sdk"`, `deployment_mode` aligned to `self_hosted | community_saas | unknown` via the new `classifyDeploymentMode` (host + `AXONFLOW_TRY=1` override). New `DeploymentMode` constants class.
 - `classifyEndpoint` no longer returns `community-saas` and `EndpointType.COMMUNITY_SAAS` is removed — that value moved off endpoint_type onto deployment_mode; analytics queries on the legacy value must update.
 
 ## [7.1.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation

--- a/examples/explain-decision/pom.xml
+++ b/examples/explain-decision/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.0.1</version>
+            <version>8.0.0</version>
         </dependency>
     </dependencies>
 

--- a/examples/list-decisions/pom.xml
+++ b/examples/list-decisions/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.0.1</version>
+            <version>8.0.0</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.getaxonflow</groupId>
     <artifactId>axonflow-sdk</artifactId>
-    <version>8.0.1</version>
+    <version>8.0.0</version>
     <packaging>jar</packaging>
 
     <name>AxonFlow Java SDK</name>


### PR DESCRIPTION
## Summary

Customer-facing CHANGELOGs document what users experience. The `profile` field added in PR #161 was removed in PR #170 **before any v8.0.0 tag shipped** — customers never installed code that had this field. The "Removed: profile field" entry I added in PR #170 referenced internal noise.

This PR:
1. Deletes the `[8.0.1]` CHANGELOG section entirely.
2. Scrubs `profile` mentions from the `[8.0.0]` section.
3. Reverts version bump `8.0.1` → `8.0.0` in `pom.xml` + 2 example poms.

Code state unchanged.

## Why

User direction: "This never made it to any customer so why it should be in changelog when we removed it already before the release."

## Skip-runtime-e2e justification

Touches \`CHANGELOG.md\` + \`pom.xml\`. While `.xml` files aren't in the auto-skip extension list, the change is documentation-only (version-revert + CHANGELOG edit) — no code behavior changes, no runtime behavior to verify. Runtime proof for the actual fix landed in #170.

## Linked

- #2033 — original bug
- #170 — code-side fix (already merged)