### PR TITLE
fix(release): add non-blocking Maven Central propagation verify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,33 @@ jobs:
             sleep 60
           done
 
+      - name: Verify version is live on Maven Central
+        # `mvn deploy` reports "Deploy successful" the moment the artifact is
+        # validated by Sonatype Central, but actual public availability on
+        # repo1.maven.org/maven2 lags by 10-30 minutes for typical releases.
+        # We poll up to ~30 minutes (60 × 30s) so the workflow's "completed"
+        # state aligns with public-availability rather than just upload-success.
+        # Non-blocking: a failure here does NOT fail the workflow (the GH release
+        # step still fires) — propagation can occasionally exceed 30 min, in
+        # which case we want the GH release published anyway and the warning
+        # surfaced for operator follow-up.
+        continue-on-error: true
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          POM_URL="https://repo1.maven.org/maven2/com/getaxonflow/axonflow-sdk/${VERSION}/axonflow-sdk-${VERSION}.pom"
+          for i in $(seq 1 60); do
+            if curl -sf -o /dev/null "$POM_URL"; then
+              echo "✅ axonflow-sdk:${VERSION} is live on Maven Central (after ${i} attempt(s) — ~$((i*30))s)"
+              echo "   $POM_URL"
+              exit 0
+            fi
+            echo "Waiting for Maven Central propagation… (attempt ${i}/60)"
+            sleep 30
+          done
+          echo "::warning::axonflow-sdk:${VERSION} not yet on repo1.maven.org after 30 minutes."
+          echo "::warning::Sonatype \`mvn deploy\` succeeded earlier in this job; propagation is sometimes >30 min."
+          echo "::warning::Verify manually at https://central.sonatype.com/publishing/deployments and $POM_URL ; not blocking the GitHub release."
+
       - name: Download release body artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:


### PR DESCRIPTION
## Summary

The release workflow reports "Deploy successful" the moment Sonatype Central validates the upload (per the v8.0.0 release [run 25604825388](https://github.com/getaxonflow/axonflow-sdk-java/actions/runs/25604825388) at 2026-05-09 15:37Z), then proceeds straight to creating the GitHub Release. But actual public availability on \`repo1.maven.org/maven2\` lags 10-30 minutes — operators couldn't tell whether the release was truly consumable.

## Change

Add a polling step between \`mvn deploy\` and the GitHub Release that checks \`repo1.maven.org\` for the artifact .pom directly. Up to 30 min (60 × 30s).

\`continue-on-error: true\` keeps it non-blocking — if propagation exceeds 30 min, the GH release still fires and a clear warning points the operator at the Sonatype publish dashboard.

## DoD (dryrun)

Ran the polling logic locally against two real versions:

\`\`\`
$ # v7.1.0 (known propagated, prior release):
✅ axonflow-sdk:7.1.0 is live (after 1 attempt(s))

$ # v8.0.0 (just published, propagation in flight at deploy time):
✅ already propagated to Maven Central — https://repo1.maven.org/maven2/com/getaxonflow/axonflow-sdk/8.0.0/axonflow-sdk-8.0.0.pom
\`\`\`

(v8.0.0 has now propagated since the original release run, ~25 min after \`mvn deploy\`.)

## Self-review

- [x] YAML still parses (\`python3 -c 'yaml.safe_load(...)'\`).
- [x] Bash block in the \`run:\` step has valid syntax (\`bash -n\`).
- [x] \`POM_URL\` host + path match \`pom.xml\` \`<groupId>com.getaxonflow</groupId>\` + \`<artifactId>axonflow-sdk</artifactId>\` exactly.
- [x] Step inserted BEFORE GitHub Release creation so the release notes can reference availability state, but \`continue-on-error\` keeps the GH release un-blocked.

No source / pom.xml / artifact change.