### PR TITLE
chore(ci): cancel orphaned PR runs + prune Java matrix on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+# Cancel orphaned PR runs when a new commit is pushed; push to main uses SHA so
+# main runs never queue or cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   AXONFLOW_TELEMETRY: 'off'
 
@@ -17,8 +23,12 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      # PR runs only Java 17 (current release toolchain). Push to main and
+      # workflow_dispatch run the full [11, 17, 21] matrix to validate
+      # version-specific drift before the next tag. Cuts PR-time wallclock
+      # ~2/3 (5.2m → ~2m on the heaviest workflow in the SDK fleet).
       matrix:
-        java-version: [11, 17, 21]
+        java-version: ${{ fromJson(github.event_name == 'pull_request' && '[17]' || '[11, 17, 21]') }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,26 @@ jobs:
         if: matrix.java-version == 17
         run: mvn jacoco:check -B
 
+  # Aggregator that always reports a single check name regardless of the
+  # matrix shape (PR-time matrix is `[17]`; push/dispatch is `[11, 17, 21]`).
+  # Branch protection requires `Build Summary`, not the per-version names,
+  # so matrix changes don't strand required checks.
+  build-summary:
+    name: Build Summary
+    needs: [build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate build matrix result
+        run: |
+          result="${{ needs.build.result }}"
+          echo "build matrix result: $result"
+          if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+            echo "::error::build matrix did not all pass (result: $result)"
+            exit 1
+          fi
+          echo "Build matrix OK"
+
   lint:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/definition-of-done.yml
+++ b/.github/workflows/definition-of-done.yml
@@ -6,11 +6,18 @@ name: Definition of Done
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    # Trim out non-diff-changing event types: dropped `edited` (title/body
+    # edit re-runs the gate without any code change). `reopened` retained for
+    # PRs that were closed and reopened with new commits.
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
   pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint-no-mocks-in-runtime-e2e:

--- a/.github/workflows/heartbeat-real-stack.yml
+++ b/.github/workflows/heartbeat-real-stack.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   AXONFLOW_TELEMETRY: 'off'
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,10 +15,11 @@ permissions:
   contents: read
 
 # Avoid spawning parallel docker-compose stacks for back-to-back pushes;
-# also cancels stale PR runs when a new commit lands.
+# also cancels stale PR runs when a new commit lands. Push to main keys on SHA
+# so main runs never queue or cancel each other.
 concurrency:
-  group: integration-${{ github.ref }}
-  cancel-in-progress: true
+  group: integration-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   AXONFLOW_TELEMETRY: 'off'
@@ -33,8 +34,10 @@ jobs:
     timeout-minutes: 15
     strategy:
       fail-fast: false
+      # PR runs only Java 17 (release toolchain). Push, dispatch, and weekly
+      # cron run the full [11, 17, 21] matrix to catch version drift.
       matrix:
-        java-version: [11, 17, 21]
+        java-version: ${{ fromJson(github.event_name == 'pull_request' && '[17]' || '[11, 17, 21]') }}
     steps:
       - name: Checkout SDK
         uses: actions/checkout@v4

--- a/.github/workflows/validate-version-alignment.yml
+++ b/.github/workflows/validate-version-alignment.yml
@@ -28,6 +28,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   AXONFLOW_TELEMETRY: 'off'
 

--- a/.github/workflows/wire-shape-contract.yml
+++ b/.github/workflows/wire-shape-contract.yml
@@ -33,6 +33,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   wire-shape:
     name: Validate Wire Shape


### PR DESCRIPTION
## Summary

Same patterns shipped on \`axonflow-enterprise\` (#2140, #2146), now applied here.

### Changes

| Workflow | Change |
|---|---|
| ci.yml | + concurrency block; matrix prune \`[11,17,21]\` → \`[17]\` on PR |
| integration.yml | concurrency reshaped to PR-only cancel; same matrix prune on contract-integration job |
| heartbeat-real-stack.yml | + concurrency block |
| wire-shape-contract.yml | + concurrency block |
| definition-of-done.yml | + concurrency block; drop \`edited\` PR event type |
| validate-version-alignment.yml | + concurrency block |

### Concurrency pattern

\`\`\`yaml
concurrency:
  group: \${{ github.workflow }}-\${{ github.event.pull_request.number || github.sha }}
  cancel-in-progress: \${{ github.event_name == 'pull_request' }}
\`\`\`

PR rebases cancel orphans by PR#; push-to-main runs each get a unique SHA group, so main builds never queue or cancel each other.

### Matrix prune

\`\`\`yaml
java-version: \${{ fromJson(github.event_name == 'pull_request' && '[17]' || '[11, 17, 21]') }}
\`\`\`

PR-time validation runs only Java 17 (current release toolchain). Push-to-main, workflow_dispatch, and the existing weekly Tuesday cron all run the full \`[11, 17, 21]\` matrix to catch version-specific drift before tagging.

### Expected impact

- ci.yml p95: ~5.2m → ~2m on PR (3 parallel java legs → 1)
- integration.yml contract-integration: same shape, same magnitude
- Other workflows: no wallclock change; concurrency just cancels orphans on rebases

Public repo, free minutes — this is dev-velocity work, not cost.

## Test plan

- [ ] CI: this PR's own runs show only 1 java-version leg (\`build (17)\`)
- [ ] CI passes; both Test/Build summary checks green
- [ ] Sanity rebase: push a tiny commit, confirm prior run cancels (concurrency working)