### PR TITLE
test(2275): 401-not-retried regression test [skip-runtime-e2e]

### DIFF
--- a/src/test/java/com/getaxonflow/sdk/AuditToolCallTest.java
+++ b/src/test/java/com/getaxonflow/sdk/AuditToolCallTest.java
@@ -243,4 +243,34 @@ class AuditToolCallTest {
     assertThat(str).contains("aud_1");
     assertThat(str).contains("recorded");
   }
+
+  // Regression test for getaxonflow/axonflow-enterprise#2275: 401 on
+  // /api/v1/audit/tool-call must be terminal — the SDK must NOT retry an
+  // auth failure, because retrying with the same invalid token just
+  // compounds the storm on the agent (716 × 401 / 24h observed from one
+  // source IP against community-saas on 2026-05-19).
+  //
+  // Java SDK is already safe: the orchestrator response handler maps 401
+  // to AuthenticationException (AxonFlow.java handleErrorResponse) and
+  // RetryExecutor.isRetryable returns false for AuthenticationException
+  // (RetryExecutor.java:119-122). This test locks in the contract
+  // end-to-end through the WireMock HTTP path, since the existing
+  // RetryExecutorTest.shouldNotRetryOnAuthenticationException is at the
+  // exception-class level rather than the HTTP-status-code level.
+  @Test
+  @DisplayName("401 must not be retried — issue #2275")
+  void shouldNotRetryOn401Issue2275() {
+    stubFor(
+        post(urlEqualTo("/api/v1/audit/tool-call"))
+            .willReturn(aResponse().withStatus(401).withBody("{\"error\":\"unauthorized\"}")));
+
+    AuditToolCallRequest request =
+        AuditToolCallRequest.builder().toolName("web_search").build();
+
+    assertThatThrownBy(() -> axonflow.auditToolCall(request))
+        .isInstanceOf(AxonFlowException.class);
+
+    // wiremock counts requests; exactly one means the SDK did NOT retry.
+    verify(1, postRequestedFor(urlEqualTo("/api/v1/audit/tool-call")));
+  }
 }


### PR DESCRIPTION
## Summary

Adds an explicit regression test asserting HTTP 401 responses on `/api/v1/audit/tool-call` are terminal — the SDK never retries a 401 auth failure.

Backstops issue [getaxonflow/axonflow-enterprise#2275](https://github.com/getaxonflow/axonflow-enterprise/issues/2275), where a customer's misconfigured deployment caused a tight 401 retry loop against `community-saas` — 716 × 401 in 24 hours from a single source IP (~30/hour, not human pacing).

## Audit finding (no code change required)

Java SDK was already safe:

- `AxonFlow.handleErrorResponse` maps HTTP 401 to `AuthenticationException`
- `RetryExecutor.isRetryable` returns `false` for `AuthenticationException` (`src/main/java/com/getaxonflow/sdk/util/RetryExecutor.java:117-146`)

The existing `RetryExecutorTest.shouldNotRetryOnAuthenticationException` tests this at the *exception-class* level. This PR adds an *end-to-end HTTP-status-code-level* test against the specific endpoint named in #2275.

## Mutation test (proves the assertion isn't tautological)

Per `feedback_mutation_test_to_prove_assertion_not_tautological.md`: removed `AuthenticationException` from the non-retryable list AND broadened the `AxonFlowException` retry check from `>= 500` to `>= 400`:

```diff
-    if (e instanceof AuthenticationException
+    if (e instanceof PolicyViolationException
         || e instanceof PolicyViolationException
...
-      return statusCode >= 500 && statusCode < 600;
+      return statusCode >= 400 && statusCode < 600;
```

Test result with mutation: **FAILED** —
```
AuditToolCallTest.shouldNotRetryOn401Issue2275:274 Expected exactly 1 requests matching the following pattern but received 3
```

→ confirms the `verify(1, ...)` assertion distinguishes "401 is terminal" vs "401 retries 3 times."

## Companion work in #2275

The other 4 SDKs (Python, Go, Rust, TypeScript) get the same regression test in their respective repos. Plugins (claude/cursor/codex/openclaw) get a similar audit in follow-on PRs after user clarified storm was primarily seen on plugins.

## Skip-runtime-e2e justification

Test-only addition; no new SDK feature surface and no wire-protocol change. The existing `runtime-e2e/` runners stay intact.

## Test plan

- [x] `mvn test -Dtest=AuditToolCallTest#shouldNotRetryOn401Issue2275` passes locally
- [x] Mutation test: making AuthenticationException retryable AND broadening status-code retry to 400+ fails the test
- [ ] CI green on this PR