### PR TITLE
Clarify evaluation and design partner paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Official Java SDK for [AxonFlow](https://getaxonflow.com) - AI Governance Platfo
 > - **Self-serve:** free 90-day [Evaluation License](https://getaxonflow.com/evaluation-license?utm_source=readme_sdk_java_eval)
 > - **Hands-on:** [Design Partner Program](https://getaxonflow.com/design-partner?utm_source=readme_sdk_java) with either **6 months of self-hosted / in-VPC Enterprise** at no cost or **3 months of AxonFlow-managed Enterprise SaaS** with SLO-backed support, up to **50,000 write requests / 1,000,000 total requests per month**
 >
-> Priority support, architecture review, and roadmap input are included for selected partners. We reply within 48 hours.
+> Priority support, architecture review, incident-readiness review, and roadmap input are included for selected partners. We reply within 48 hours.
 
 > **Questions or feedback?**
 >

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Official Java SDK for [AxonFlow](https://getaxonflow.com) - AI Governance Platfo
 
 > **Upgrade strongly recommended.** AxonFlow ships substantial monthly security and quality hardening; staying on the latest major is the security-supported release line. [Latest release](https://github.com/getaxonflow/axonflow-sdk-java/releases/latest) · [Security advisories](https://github.com/getaxonflow/axonflow-sdk-java/security/advisories)
 
-> **Evaluating AxonFlow in production?** We're opening limited Design Partner slots.
+> **Evaluating AxonFlow for a real deployment?**
 >
-> Free 30-minute architecture and incident-readiness review, priority issue triage, roadmap input, and early feature access.
+> Choose the path that fits:
+> - **Self-serve:** free 90-day [Evaluation License](https://getaxonflow.com/evaluation-license?utm_source=readme_sdk_java_eval)
+> - **Hands-on:** [Design Partner Program](https://getaxonflow.com/design-partner?utm_source=readme_sdk_java) with either **6 months of self-hosted / in-VPC Enterprise** at no cost or **3 months of AxonFlow-managed Enterprise SaaS** with SLO-backed support, up to **50,000 write requests / 1,000,000 total requests per month**
 >
-> [Apply here](https://getaxonflow.com/design-partner?utm_source=readme_sdk_java) or email [design-partners@getaxonflow.com](mailto:design-partners@getaxonflow.com).
->
-> No commitment required. We reply within 48 hours.
+> Priority support, architecture review, and roadmap input are included for selected partners. We reply within 48 hours.
 
 > **Questions or feedback?**
 >
@@ -75,7 +75,7 @@ Concurrent executions applies to MAP and WCP executions per tenant. Pending exec
 
 > **Note:** Evidence export and policy simulation are licensed AxonFlow platform capabilities available alongside the SDK on your deployed platform — not language-specific SDK helpers. Access them via the platform API or customer portal. The SDK row is included to show what your licensed deployment unlocks at each tier.
 
-[Get a free Evaluation license](https://getaxonflow.com/evaluation-license?utm_source=readme_sdk_java_eval) · [Full feature matrix](https://docs.getaxonflow.com/docs/features/community-vs-enterprise?utm_source=readme_sdk_java_eval)
+[Get a free Evaluation license](https://getaxonflow.com/evaluation-license?utm_source=readme_sdk_java_eval) · [Apply for Design Partner](https://getaxonflow.com/design-partner?utm_source=readme_sdk_java_eval) · [Full feature matrix](https://docs.getaxonflow.com/docs/features/community-vs-enterprise?utm_source=readme_sdk_java_eval)
 
 ## Try Without Installing
 


### PR DESCRIPTION
## Summary
- make the README more explicit about the self-serve evaluation path
- add the stronger design partner offer for serious teams
- keep the production rollout motion visible near the top of the package entry point

## Why
The README is a high-intent entry point. Teams evaluating real deployments should immediately see the right next step.