### PR TITLE
docs(2275): remove non-existent RetryConfig.Builder methods from README [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the AxonFlow Java SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **README "Retry Configuration" section.** Removed three `RetryConfig.Builder`
+  methods that do not exist on the public API (`initialDelayMs(int)`,
+  `maxDelayMs(int)`, `retryableStatusCodes(Set<Integer>)`). The example now
+  uses the actual `initialDelay(Duration)` / `maxDelay(Duration)` builders, and
+  the surrounding prose documents the real retry contract from
+  `RetryExecutor.isRetryable`: retries fire on connect/timeout, `5xx`, and
+  `429`; `401`/`403` and other `4xx` are always terminal. Locked in by the
+  regression test added for
+  [getaxonflow/axonflow-enterprise#2275](https://github.com/getaxonflow/axonflow-enterprise/issues/2275)
+  in PR #178. Documentation-only — no code or behavior change.
+
 ## [8.1.0] - 2026-05-19 — `X-Client-ID` header on every outbound request (v9 identity)
 
 **Companion release to the v9 identity cleanup on the platform (Epic #2230).**

--- a/README.md
+++ b/README.md
@@ -337,19 +337,35 @@ try {
 
 ## Retry Configuration
 
-The SDK includes automatic retry with exponential backoff:
+The SDK includes automatic retry with exponential backoff. The retry policy
+itself is not configurable per HTTP status — retries fire on connect/timeout
+errors, `5xx` server errors, and `429 Too Many Requests`. Authentication
+failures (`401`/`403`), policy violations, and other `4xx` client errors are
+always terminal and never retried (see `RetryExecutor.isRetryable`). This
+contract is locked in as a regression test for
+[getaxonflow/axonflow-enterprise#2275](https://github.com/getaxonflow/axonflow-enterprise/issues/2275)
+— a retry storm on `401` against a misconfigured agent.
+
+The `RetryConfig.Builder` exposes the following knobs:
+
+- `enabled(boolean)` — turn retries off entirely (defaults to `true`).
+- `maxAttempts(int)` — total attempts including the first, `1`–`10` (default `3`).
+- `initialDelay(Duration)` — base delay before the second attempt (default `1s`).
+- `maxDelay(Duration)` — cap on the exponential backoff (default `30s`).
+- `multiplier(double)` — backoff multiplier, ≥ `1.0` (default `2.0`).
 
 ```java
+import java.time.Duration;
+
 AxonFlowConfig config = AxonFlowConfig.builder()
     .endpoint("https://agent.getaxonflow.com")
     .clientId("your-client-id")
-            .clientSecret("your-client-secret")
+    .clientSecret("your-client-secret")
     .retryConfig(RetryConfig.builder()
         .maxAttempts(3)
-        .initialDelayMs(100)
-        .maxDelayMs(5000)
+        .initialDelay(Duration.ofMillis(100))
+        .maxDelay(Duration.ofSeconds(5))
         .multiplier(2.0)
-        .retryableStatusCodes(Set.of(429, 500, 502, 503, 504))
         .build())
     .build();
 ```


### PR DESCRIPTION
## Summary

Follow-up to PR #178 (regression test for [getaxonflow/axonflow-enterprise#2275](https://github.com/getaxonflow/axonflow-enterprise/issues/2275) — the 401 retry storm against a misconfigured agent).

Hostile review of PR #178 flagged a HIGH doc-debt finding on `README.md:347-353`: three `RetryConfig.Builder` methods that do **not** exist in the public API. PR #178's author punted on the fix. This PR closes the finding.

### What the README lied about

| README claim | Actual public API |
|---|---|
| `initialDelayMs(int)` | `initialDelay(Duration)` — see [`RetryConfig.java:165`](https://github.com/getaxonflow/axonflow-sdk-java/blob/main/src/main/java/com/getaxonflow/sdk/util/RetryConfig.java#L165) |
| `maxDelayMs(int)` | `maxDelay(Duration)` — see [`RetryConfig.java:173`](https://github.com/getaxonflow/axonflow-sdk-java/blob/main/src/main/java/com/getaxonflow/sdk/util/RetryConfig.java#L173) |
| `retryableStatusCodes(Set<Integer>)` | **Does not exist.** The retry policy is hard-coded in [`RetryExecutor.isRetryable`](https://github.com/getaxonflow/axonflow-sdk-java/blob/main/src/main/java/com/getaxonflow/sdk/util/RetryExecutor.java#L117): `5xx` + `429` + connect/timeout exceptions retry; `401`/`403`/policy/config exceptions are terminal. |

The `retryableStatusCodes` lie was load-bearing in the #2275 context. A user reading the README would expect to be able to configure which statuses retry. If they looked for it and didn't find it, they might write a workaround that bypassed `RetryExecutor` entirely — reintroducing the 401 storm that PR #178 added regression coverage for.

### Why delete, not implement

Implementing `retryableStatusCodes` would be a **feature addition** (new configuration surface + serialized semantics + tests + cross-SDK parity work + ADR), not a doc fix. This follow-up PR is scoped strictly to documentation alignment.

### What this PR does

1. **`README.md`** — replaces the misleading code block with:
   - one paragraph documenting the **actual** retry contract (citing `RetryExecutor.isRetryable` and #2275 by URL),
   - a list of every `RetryConfig.Builder` method that **actually exists** (`enabled`, `maxAttempts`, `initialDelay`, `maxDelay`, `multiplier`) with default values,
   - a working code example using `initialDelay(Duration.ofMillis(100))` / `maxDelay(Duration.ofSeconds(5))` that compiles against the real public API.
2. **`CHANGELOG.md`** — `[Unreleased] > Fixed` entry noting the README correction. Documentation-only — no public-API or behavior change.

### R3 hostile self-review

- [x] **Deleted strings are unique.** `grep -rn "initialDelayMs\|maxDelayMs\|retryableStatusCodes"` across the repo returns only the `CHANGELOG.md` change in this PR (inside backticks, framed as "do not exist on the public API" — a deliberate record of the deletion, not a re-introduction).
- [x] **Replacement prose matches the implementation.** Line-by-line checked against `RetryExecutor.isRetryable`:
  - Retryable: `ConnectionException`, `TimeoutException`, `SocketTimeoutException`, `IOException`, `RateLimitException` (429), 5xx → matches README "connect/timeout errors, 5xx server errors, and 429".
  - Terminal: `AuthenticationException`, `PolicyViolationException`, `ConfigurationException`, default 4xx → matches README "401/403, policy violations, and other 4xx client errors are always terminal".
- [x] **All real Builder methods documented.** `RetryConfig.java:139-192` Builder has `enabled`, `maxAttempts`, `initialDelay`, `maxDelay`, `multiplier`. All 5 listed in the README bullet list with their defaults from the `DEFAULT_*` constants.
- [x] **No orphan imports.** Old example used `Set.of(...)`; new example needs `java.time.Duration` only, which is now explicitly shown as an import in the code block.

### NOT in scope

- Adding `retryableStatusCodes` or any per-status configuration to the Builder (that's a feature).
- Changing `RetryExecutor.isRetryable` behavior.
- SDK version bump.

## Skip-runtime-e2e justification

This PR touches only `README.md` and `CHANGELOG.md`. No `src/main/java/`, `pom.xml`, or `examples/` changes — the gate's `USER_FACING_GLOBS` don't match, so the gate may not even require the marker. The marker is included defensively per the repo convention so reviewers don't have to guess why no `runtime-e2e/` test was added.

The retry behavior this PR documents is **already** covered by `runtime-e2e/`-adjacent regression tests in PR #178 (`AuditToolCallTest#shouldNotRetryOn401Issue2275`). A doc-alignment fix doesn't introduce any new code path to exercise.