### PR TITLE
[HOLD-for-9.0.0][skip-runtime-e2e] docs(decisions): canonical /decisions verdict values

### DIFF
--- a/examples/list-decisions/src/main/java/com/getaxonflow/examples/ListDecisions.java
+++ b/examples/list-decisions/src/main/java/com/getaxonflow/examples/ListDecisions.java
@@ -14,7 +14,9 @@
 //   mvn -q compile exec:java
 //
 // Optional filters via env:
-//   AXONFLOW_LIST_DECISION       allow|deny|require_approval
+//   AXONFLOW_LIST_DECISION       allowed|blocked|redacted|needs_approval|error
+//                                (canonical audit verdicts, platform 9.0.0+;
+//                                pre-9.0.0 allow|deny|require_approval now 400)
 //   AXONFLOW_LIST_POLICY_ID      e.g. sys_sqli_stacked_drop
 //   AXONFLOW_LIST_LIMIT          integer (server-capped per tier)
 package com.getaxonflow.examples;

--- a/src/main/java/com/getaxonflow/sdk/AxonFlow.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlow.java
@@ -756,7 +756,7 @@ public final class AxonFlow implements Closeable {
    * <pre>{@code
    * try {
    *     List<DecisionSummary> decisions = axonflow.listDecisions(
-   *         ListDecisionsOptions.builder().decision("deny").limit(10).build());
+   *         ListDecisionsOptions.builder().decision("blocked").limit(10).build());
    *     for (DecisionSummary d : decisions) {
    *         System.out.println(d.getDecisionId() + " " + d.getDecision());
    *     }

--- a/src/main/java/com/getaxonflow/sdk/types/DecisionExplanation.java
+++ b/src/main/java/com/getaxonflow/sdk/types/DecisionExplanation.java
@@ -88,6 +88,7 @@ public final class DecisionExplanation {
     return matchedRules;
   }
 
+  /** Canonical audit verdict: allowed | blocked | redacted | needs_approval | error (9.0.0+). */
   public String getDecision() {
     return decision;
   }

--- a/src/main/java/com/getaxonflow/sdk/types/DecisionSummary.java
+++ b/src/main/java/com/getaxonflow/sdk/types/DecisionSummary.java
@@ -63,7 +63,7 @@ public final class DecisionSummary {
     return timestamp;
   }
 
-  /** allow | deny | require_approval */
+  /** Canonical audit verdict: allowed | blocked | redacted | needs_approval | error (9.0.0+). */
   public String getDecision() {
     return decision;
   }

--- a/src/main/java/com/getaxonflow/sdk/types/ListDecisionsOptions.java
+++ b/src/main/java/com/getaxonflow/sdk/types/ListDecisionsOptions.java
@@ -11,8 +11,12 @@ import java.time.Instant;
  * Optional filters for {@code AxonFlow.listDecisions}.
  *
  * <p>Every field is optional; null values are omitted from the URL so the
- * platform applies its tier-default page. {@code decision} must be one of
- * {@code "allow"}, {@code "deny"}, or {@code "require_approval"} when set.
+ * platform applies its tier-default page. {@code decision}, when set, must be one
+ * of the canonical audit verdicts {@code "allowed"}, {@code "blocked"},
+ * {@code "redacted"}, {@code "needs_approval"}, or {@code "error"} (platform
+ * 9.0.0+); the pre-9.0.0 values {@code "allow"} / {@code "deny"} /
+ * {@code "require_approval"} are rejected with HTTP 400 by 9.0.0 (see
+ * https://docs.getaxonflow.com/docs/deployment/v8-to-v9-migration/).
  * {@code limit} is server-capped per tier; over-cap requests yield a 429
  * with the V1 upgrade envelope (surfaced as {@link
  * com.getaxonflow.sdk.exceptions.RateLimitException} carrying upgrade info).
@@ -21,7 +25,7 @@ import java.time.Instant;
  *
  * <pre>{@code
  * ListDecisionsOptions opts = ListDecisionsOptions.builder()
- *     .decision("deny")
+ *     .decision("blocked")
  *     .limit(10)
  *     .build();
  * List<DecisionSummary> decisions = client.listDecisions(opts);

--- a/src/test/java/com/getaxonflow/sdk/DecisionExplainTest.java
+++ b/src/test/java/com/getaxonflow/sdk/DecisionExplainTest.java
@@ -26,7 +26,7 @@ class DecisionExplainTest {
       "{"
           + "\"decision_id\": \"dec_wf1_step2\","
           + "\"timestamp\": \"2026-04-17T12:00:00Z\","
-          + "\"decision\": \"deny\","
+          + "\"decision\": \"blocked\","
           + "\"reason\": \"SQL injection detected\","
           + "\"risk_level\": \"high\","
           + "\"policy_matches\": [{"
@@ -87,7 +87,7 @@ class DecisionExplainTest {
     DecisionExplanation exp = axonflow.explainDecision("dec_wf1_step2");
 
     assertThat(exp.getDecisionId()).isEqualTo("dec_wf1_step2");
-    assertThat(exp.getDecision()).isEqualTo("deny");
+    assertThat(exp.getDecision()).isEqualTo("blocked");
     assertThat(exp.getReason()).isEqualTo("SQL injection detected");
     assertThat(exp.getRiskLevel()).isEqualTo("high");
     assertThat(exp.getPolicyMatches()).hasSize(1);
@@ -108,7 +108,7 @@ class DecisionExplainTest {
         "{"
             + "\"decision_id\": \"dec-ctx\","
             + "\"timestamp\": \"2026-05-30T12:00:00Z\","
-            + "\"decision\": \"deny\","
+            + "\"decision\": \"blocked\","
             + "\"reason\": \"\","
             + "\"policy_matches\": [],"
             + "\"override_available\": false,"
@@ -133,7 +133,7 @@ class DecisionExplainTest {
   void contextAbsentDefaults() {
     String body =
         "{\"decision_id\":\"dec-1\",\"timestamp\":\"2026-04-17T12:00:00Z\","
-            + "\"decision\":\"allow\",\"reason\":\"\",\"policy_matches\":[],"
+            + "\"decision\":\"allowed\",\"reason\":\"\",\"policy_matches\":[],"
             + "\"override_available\":false,\"historical_hit_count_session\":0}";
     stubFor(
         get(urlEqualTo("/api/v1/decisions/dec-1/explain"))
@@ -240,7 +240,7 @@ class DecisionExplainTest {
             java.time.Instant.now(),
             null, // policyMatches null should default to empty
             null,
-            "allow",
+            "allowed",
             "",
             null,
             false,

--- a/src/test/java/com/getaxonflow/sdk/ListDecisionsTest.java
+++ b/src/test/java/com/getaxonflow/sdk/ListDecisionsTest.java
@@ -45,23 +45,23 @@ class ListDecisionsTest {
                     .withBody(
                         "{\"decisions\":["
                             + "{\"decision_id\":\"dec-1\",\"timestamp\":\"2026-05-07T12:00:00Z\","
-                            + "\"decision\":\"deny\",\"policy_id\":\"pol-sqli\","
+                            + "\"decision\":\"blocked\",\"policy_id\":\"pol-sqli\","
                             + "\"tool_signature\":\"postgres.query\"},"
                             + "{\"decision_id\":\"dec-2\",\"timestamp\":\"2026-05-07T11:00:00Z\","
-                            + "\"decision\":\"allow\",\"policy_id\":\"pol-default\","
+                            + "\"decision\":\"allowed\",\"policy_id\":\"pol-default\","
                             + "\"tool_signature\":\"github.status\"},"
                             + "{\"decision_id\":\"dec-3\",\"timestamp\":\"2026-05-07T10:00:00Z\","
-                            + "\"decision\":\"require_approval\",\"policy_id\":\"pol-amount\","
+                            + "\"decision\":\"needs_approval\",\"policy_id\":\"pol-amount\","
                             + "\"tool_signature\":\"stripe.charge\"}"
                             + "]}")));
 
     List<DecisionSummary> got = axonflow.listDecisions(null);
     assertThat(got).hasSize(3);
     assertThat(got.get(0).getDecisionId()).isEqualTo("dec-1");
-    assertThat(got.get(0).getDecision()).isEqualTo("deny");
+    assertThat(got.get(0).getDecision()).isEqualTo("blocked");
     assertThat(got.get(0).getPolicyId()).isEqualTo("pol-sqli");
     assertThat(got.get(0).getToolSignature()).isEqualTo("postgres.query");
-    assertThat(got.get(2).getDecision()).isEqualTo("require_approval");
+    assertThat(got.get(2).getDecision()).isEqualTo("needs_approval");
   }
 
   @Test
@@ -76,11 +76,11 @@ class ListDecisionsTest {
                     .withBody(
                         "{\"decisions\":["
                             + "{\"decision_id\":\"dec-ctx\",\"timestamp\":\"2026-05-30T12:00:00Z\","
-                            + "\"decision\":\"deny\",\"context\":{"
+                            + "\"decision\":\"blocked\",\"context\":{"
                             + "\"x_ai_agent\":\"refund-bot\",\"x_session_id\":\"sess-42\","
                             + "\"x_leader_identity\":\"ops-lead\"}},"
                             + "{\"decision_id\":\"dec-noctx\",\"timestamp\":\"2026-05-30T11:00:00Z\","
-                            + "\"decision\":\"allow\"}"
+                            + "\"decision\":\"allowed\"}"
                             + "]}")));
 
     List<DecisionSummary> got = axonflow.listDecisions(null);
@@ -100,7 +100,7 @@ class ListDecisionsTest {
     stubFor(
         get(urlPathEqualTo("/api/v1/decisions"))
             .withQueryParam("since", equalTo("2026-05-07T00:00:00Z"))
-            .withQueryParam("decision", equalTo("deny"))
+            .withQueryParam("decision", equalTo("blocked"))
             .withQueryParam("policy_id", equalTo("pol-sqli"))
             .withQueryParam("tool_signature", equalTo("postgres.query"))
             .withQueryParam("limit", equalTo("25"))
@@ -109,7 +109,7 @@ class ListDecisionsTest {
     ListDecisionsOptions opts =
         ListDecisionsOptions.builder()
             .since(Instant.parse("2026-05-07T00:00:00Z"))
-            .decision("deny")
+            .decision("blocked")
             .policyId("pol-sqli")
             .toolSignature("postgres.query")
             .limit(25)
@@ -123,7 +123,7 @@ class ListDecisionsTest {
   void omitsUnsetFilters() {
     stubFor(
         get(urlPathEqualTo("/api/v1/decisions"))
-            .withQueryParam("decision", equalTo("deny"))
+            .withQueryParam("decision", equalTo("blocked"))
             // wiremock fails the test if the URL contains any of these:
             .withQueryParam("policy_id", absent())
             .withQueryParam("tool_signature", absent())
@@ -131,7 +131,7 @@ class ListDecisionsTest {
             .withQueryParam("since", absent())
             .willReturn(aResponse().withStatus(200).withBody("{\"decisions\":[]}")));
 
-    axonflow.listDecisions(ListDecisionsOptions.builder().decision("deny").build());
+    axonflow.listDecisions(ListDecisionsOptions.builder().decision("blocked").build());
   }
 
   @Test
@@ -219,7 +219,7 @@ class ListDecisionsTest {
                         "{\"decisions\":[{"
                             + "\"decision_id\":\"dec-fwd\","
                             + "\"timestamp\":\"2026-05-07T12:00:00Z\","
-                            + "\"decision\":\"deny\","
+                            + "\"decision\":\"blocked\","
                             + "\"policy_id\":\"pol-x\","
                             + "\"tool_signature\":\"tool-x\","
                             + "\"policy_version\":7,"
@@ -244,7 +244,7 @@ class ListDecisionsTest {
                         "{\"decisions\":[{"
                             + "\"decision_id\":\"dec-min\","
                             + "\"timestamp\":\"2026-05-07T12:00:00Z\","
-                            + "\"decision\":\"deny\""
+                            + "\"decision\":\"blocked\""
                             + "}]}")));
 
     List<DecisionSummary> got = axonflow.listDecisions(null);
@@ -263,8 +263,8 @@ class ListDecisionsTest {
   @DisplayName("buildListDecisionsQuery — partial options omit None fields")
   void buildQueryPartial() {
     ListDecisionsOptions opts =
-        ListDecisionsOptions.builder().decision("deny").limit(7).build();
-    assertThat(AxonFlow.buildListDecisionsQuery(opts)).isEqualTo("?decision=deny&limit=7");
+        ListDecisionsOptions.builder().decision("blocked").limit(7).build();
+    assertThat(AxonFlow.buildListDecisionsQuery(opts)).isEqualTo("?decision=blocked&limit=7");
   }
 
   @Test


### PR DESCRIPTION
## ⛔ HELD — do NOT merge until the 9.0.0 release ships

Pre-release docs/example refresh for **9.0.0**. The `/api/v1/decisions` read surface canonicalized on the platform (merged on `axonflow-enterprise` `main`, not yet released): the endpoint returns `allowed|blocked|redacted|needs_approval|error` and the `?decision=` filter rejects the old `allow|deny|require_approval` with **HTTP 400**. This PR merges at the 9.0.0 cut alongside the held migration guide. Ready-for-review so it can be approved now.

Tracking: getaxonflow/axonflow-enterprise#2669 (follow-up to the #2668 SDK sweep). Migration guide: getaxonflow/axonflow-docs#554.

## What this changes (docs / examples / fixtures only — no logic or type change)

- `DecisionSummary.java` + `DecisionExplanation.java` `getDecision()` Javadoc + `ListDecisionsOptions.java` filter doc → canonical, with the migration-guide pointer.
- `examples/list-decisions/.../ListDecisions.java` — the `AXONFLOW_LIST_DECISION` env-var doc → canonical values.
- `ListDecisionsTest.java` + `DecisionExplainTest.java` — `decision`-verdict fixtures/asserts + wiremock query-param stubs → canonical, kept green.

## Explicitly NOT touched (different, unchanged surfaces)

- The wire `/api/v1/decide` verdict (`allow|deny|needs_approval`) and the pre-check response `decision` field — frozen PEP enforcement contract.
- The workflow-control / WCP gate decision (`allow|block|require_approval` in the WCP gate types
- the `ExplainPolicy` policy-action vocab and `reason` strings.

## Validation

- Full unit suite green: **full `mvn test` green (1303 tests, 0 failures, 0 errors).
- Repo grep is clean of stale `/decisions` verdict values (only the intentional migration-reference text remains).
- DCO signed; conventional title; no AI attribution.


## Skip-runtime-e2e justification

Docs / examples / test-fixtures only — no runtime behavior or wire change. The SDK forwards the `/decisions` `?decision=` filter string verbatim (no client-side validation), so there is nothing new to exercise against a live stack: this updates docstrings, the `list_decisions` example env-var doc, and test fixtures from the pre-9.0.0 `allow|deny|require_approval` vocabulary to the canonical `allowed|blocked|redacted|needs_approval|error`. Fully covered by the in-repo unit/contract tests (all green locally). Held for the 9.0.0 release.