### PR TITLE
fix(security): hard production guard on insecure-TLS hatch + workflow perms + example SDK bump

### DIFF
--- a/.github/workflows/heartbeat-real-stack.yml
+++ b/.github/workflows/heartbeat-real-stack.yml
@@ -19,6 +19,12 @@ concurrency:
 env:
   AXONFLOW_TELEMETRY: 'off'
 
+# Least-privilege token: this workflow only checks out the repo and runs
+# tests. No write access to repo contents, packages, or pull requests is
+# required.
+permissions:
+  contents: read
+
 jobs:
   real-stack:
     name: real-stack ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to the AxonFlow Java SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.5.1] - 2026-06-16: TLS security hardening (production guard)
+
+Patch release. No public API changes.
+
+### Security
+
+- **Hard production guard on the insecure-TLS escape hatch.**
+  `HttpClientFactory` already required BOTH `insecureSkipVerify(true)` on the
+  config builder AND the `AXONFLOW_INSECURE_TLS` environment variable before it
+  would disable TLS certificate verification (a development-only path for
+  self-signed certificates). It now additionally refuses to disable verification
+  whenever a production-like deployment environment is detected, even if both
+  gates are set. A production environment is signalled by any of a set of common
+  deployment environment variables (for example `ENVIRONMENT`,
+  `AXONFLOW_ENVIRONMENT`, `APP_ENV`, `SPRING_PROFILES_ACTIVE`, `NODE_ENV`)
+  carrying a `prod` or `production` token. When the guard trips, TLS certificate
+  verification remains enabled and a `SECURITY` error is logged naming the
+  signalling variable. This is belt-and-suspenders hardening; the development
+  escape hatch for local self-signed certificates is unchanged. Clears CodeQL
+  `java/insecure-trustmanager` (alert #8).
+
 ## [8.5.0] - 2026-06-09 — Decision Mode PEP: decide → fulfill → forward
 
 Adds the SDK analog of the platform PEP client (`platform/shared/pep`, ADR-056,

--- a/examples/wcp-retry-idempotency/pom.xml
+++ b/examples/wcp-retry-idempotency/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.5.0</version>
+            <version>8.5.0</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.getaxonflow</groupId>
     <artifactId>axonflow-sdk</artifactId>
-    <version>8.5.0</version>
+    <version>8.5.1</version>
     <packaging>jar</packaging>
 
     <name>AxonFlow Java SDK</name>

--- a/runtime-e2e/trustmanager_prod_guard/README.md
+++ b/runtime-e2e/trustmanager_prod_guard/README.md
@@ -1,0 +1,47 @@
+# trustmanager_prod_guard (insecure-TLS production guard, #2711)
+
+Real-stack proof that the SDK's hard production guard refuses the trust-all TLS
+escape hatch in a production-like environment, against a live AxonFlow
+enterprise agent over its **real, valid** TLS certificate, with NO mocks.
+
+Background: the SDK's trust-all `TrustManager` is an intentional, double-gated
+development affordance for self-signed certificates (it needs BOTH
+`insecureSkipVerify(true)` AND the `AXONFLOW_INSECURE_TLS` env var). The
+hardening adds a belt-and-suspenders guard: when a production-like deployment
+environment is detected (an env var such as `ENVIRONMENT`, `AXONFLOW_ENVIRONMENT`,
+`APP_ENV`, `SPRING_PROFILES_ACTIVE`, `NODE_ENV`, ... carrying a `prod`/`production`
+token), the insecure path is refused and TLS certificate verification stays ON.
+
+This test MUST be run with the guard tripped (`ENVIRONMENT=production` +
+`AXONFLOW_INSECURE_TLS=true`) and asserts:
+
+1. **Guard prevents (not just logs).** With `insecureSkipVerify(true)` AND the
+   insecure env gate AND a production signal, `HttpClientFactory.create()` leaves
+   OkHttp's default verifying hostname verifier in place; the permissive
+   `(hostname, session) -> true` lambda is never installed.
+2. **Connectivity preserved.** A real governed `decide()` call against the live
+   HTTPS agent succeeds over the agent's valid certificate, proving the kept-on
+   verification did not break legitimate connectivity.
+3. **Parity.** The guarded client is verifier-identical to a plain config that
+   never requested `insecureSkipVerify`.
+
+## Run
+
+```
+source /tmp/axonflow-e2e-env.sh   # AXONFLOW_ENDPOINT (https) + AXONFLOW_CLIENT_ID / _SECRET / _USER_TOKEN
+mvn -q -DskipTests package
+mvn -q -DskipTests dependency:build-classpath -Dmdep.outputFile=/tmp/cp.txt
+SDK_JAR=$(ls target/axonflow-sdk-*.jar | grep -v sources | grep -v javadoc | head -1)
+AXONFLOW_INSECURE_TLS=true ENVIRONMENT=production \
+  java -cp "$SDK_JAR:$(cat /tmp/cp.txt)" \
+    runtime-e2e/trustmanager_prod_guard/TrustManagerProdGuardTest.java
+```
+
+Exits non-zero (and prints `FAIL: ...`) if any step fails, for example if the
+guard let the trust-all path install, if the HTTPS call could not complete over
+verified TLS, or if the guard env preconditions were not set.
+
+The complementary negative/false-positive cases (hyphen/underscore-delimited prod
+names detected, `non-prod`/`pre-prod` correctly ignored, the guard preventing the
+insecure verifier) are covered deterministically by the unit suite in
+`src/test/java/com/getaxonflow/sdk/util/HttpClientFactoryTest.java`.

--- a/runtime-e2e/trustmanager_prod_guard/TrustManagerProdGuardTest.java
+++ b/runtime-e2e/trustmanager_prod_guard/TrustManagerProdGuardTest.java
@@ -1,0 +1,130 @@
+/*
+ * runtime-e2e/trustmanager_prod_guard/TrustManagerProdGuardTest.java
+ *
+ * Real-wire test of the insecure-TLS production guard (CodeQL
+ * java/insecure-trustmanager hardening, epic getaxonflow/axonflow-enterprise#2711)
+ * against a running AxonFlow enterprise agent over its real (valid) TLS cert.
+ *
+ * The SDK's trust-all TLS path is an intentional, double-gated development
+ * escape hatch for self-signed certificates: it activates only when BOTH
+ * insecureSkipVerify(true) AND the AXONFLOW_INSECURE_TLS env var are set. The
+ * hardening adds a HARD PRODUCTION GUARD: when a production-like deployment
+ * environment is detected, the insecure path is refused outright and TLS
+ * certificate verification stays ON.
+ *
+ * This test MUST be run with the guard tripped (ENVIRONMENT=production +
+ * AXONFLOW_INSECURE_TLS=true) and proves, with NO mocks:
+ *
+ *   1. Even though both insecure gates are set, HttpClientFactory.create() with
+ *      insecureSkipVerify(true) leaves OkHttp's default verifying hostname
+ *      verifier in place (the permissive trust-all lambda is NOT installed) ->
+ *      the guard PREVENTS the insecure path, it does not merely log.
+ *   2. A real governed decide() call against the live HTTPS agent SUCCEEDS over
+ *      the agent's valid certificate, proving the guard kept verification ON
+ *      without breaking legitimate connectivity.
+ *   3. Parity: a plain config (no insecureSkipVerify) yields the same verifier
+ *      type, confirming the guarded client is indistinguishable from the safe
+ *      default.
+ *
+ * Run (the two guard env vars are REQUIRED for this test to be meaningful):
+ *   source /tmp/axonflow-e2e-env.sh   # AXONFLOW_ENDPOINT (https) + creds
+ *   mvn -q -DskipTests package
+ *   mvn -q -DskipTests dependency:build-classpath -Dmdep.outputFile=/tmp/cp.txt
+ *   SDK_JAR=$(ls target/axonflow-sdk-*.jar | grep -v sources | grep -v javadoc | head -1)
+ *   AXONFLOW_INSECURE_TLS=true ENVIRONMENT=production \
+ *     java -cp "$SDK_JAR:$(cat /tmp/cp.txt)" \
+ *       runtime-e2e/trustmanager_prod_guard/TrustManagerProdGuardTest.java
+ */
+import com.getaxonflow.sdk.AxonFlow;
+import com.getaxonflow.sdk.AxonFlowConfig;
+import com.getaxonflow.sdk.types.DecideRequest;
+import com.getaxonflow.sdk.types.DecideResponse;
+import com.getaxonflow.sdk.util.HttpClientFactory;
+import okhttp3.OkHttpClient;
+
+public class TrustManagerProdGuardTest {
+
+  static void fail(String msg) {
+    System.err.println("FAIL: " + msg);
+    System.exit(1);
+  }
+
+  static void check(boolean cond, String msg) {
+    if (!cond) {
+      fail(msg);
+    }
+  }
+
+  public static void main(String[] args) {
+    String endpoint = System.getenv().getOrDefault("AXONFLOW_ENDPOINT", "https://localhost:8443");
+    String clientId = System.getenv("AXONFLOW_CLIENT_ID");
+    String clientSecret = System.getenv("AXONFLOW_CLIENT_SECRET");
+    String userToken = System.getenv("AXONFLOW_USER_TOKEN");
+
+    // Both insecure gates MUST be set for this test to exercise the guard; the
+    // guard is only interesting when it has something to refuse. We read the
+    // process env directly here (the SDK's gating helpers are package-private).
+    String insecureEnv = System.getenv("AXONFLOW_INSECURE_TLS");
+    check(
+        insecureEnv != null && (insecureEnv.equalsIgnoreCase("true") || insecureEnv.equals("1")),
+        "AXONFLOW_INSECURE_TLS must be set to 'true'/'1' to exercise the guard "
+            + "(run: AXONFLOW_INSECURE_TLS=true ENVIRONMENT=production java ...)");
+    String envName = System.getenv("ENVIRONMENT");
+    check(
+        envName != null && envName.toLowerCase().contains("prod"),
+        "a production-like env var (e.g. ENVIRONMENT=production) must be set so the guard trips");
+    System.out.println(
+        "guard precondition: AXONFLOW_INSECURE_TLS set AND ENVIRONMENT=" + envName);
+
+    // 1. The guard must PREVENT the trust-all path: with insecureSkipVerify(true)
+    //    AND AXONFLOW_INSECURE_TLS=true AND a production signal, the built client
+    //    must still carry OkHttp's default verifying hostname verifier (the
+    //    permissive (hostname, session) -> true lambda is NOT installed).
+    AxonFlowConfig insecureRequested =
+        AxonFlowConfig.builder().endpoint(endpoint).insecureSkipVerify(true).build();
+    OkHttpClient guardedClient = HttpClientFactory.create(insecureRequested);
+    String guardedVerifier = guardedClient.hostnameVerifier().getClass().getName();
+    check(
+        guardedVerifier.contains("OkHostnameVerifier"),
+        "production guard FAILED: trust-all verifier was installed despite a production env ("
+            + guardedVerifier
+            + ")");
+    System.out.println("PASS step 1: guard refused the trust-all path; verifier=" + guardedVerifier);
+
+    // 3. Parity with a plain config (no insecureSkipVerify): same verifier type.
+    AxonFlowConfig plain = AxonFlowConfig.builder().endpoint(endpoint).build();
+    OkHttpClient plainClient = HttpClientFactory.create(plain);
+    check(
+        guardedClient.hostnameVerifier().getClass().equals(plainClient.hostnameVerifier().getClass()),
+        "guarded client verifier type differs from the safe-default client verifier type");
+    System.out.println("PASS step 3: guarded client is verifier-identical to the safe default");
+
+    // 2. A real governed call must SUCCEED over the agent's valid TLS cert,
+    //    proving the kept-on verification did not break legitimate connectivity.
+    if (clientId == null || clientSecret == null) {
+      fail("AXONFLOW_CLIENT_ID / AXONFLOW_CLIENT_SECRET unset -- source /tmp/axonflow-e2e-env.sh");
+    }
+    if (!endpoint.startsWith("https://")) {
+      fail("AXONFLOW_ENDPOINT must be https:// for the TLS-verification assertion to be meaningful");
+    }
+    AxonFlow client =
+        AxonFlow.create(
+            AxonFlowConfig.builder()
+                .endpoint(endpoint)
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .insecureSkipVerify(true) // requested, but the guard keeps verification ON
+                .build());
+    DecideResponse decision =
+        client.decide(DecideRequest.builder("tool", "ping").userToken(userToken).build());
+    check(
+        decision != null && decision.getVerdict() != null,
+        "expected a non-null verdict from the live agent over verified TLS");
+    System.out.println(
+        "PASS step 2: governed decide() succeeded over verified TLS, verdict="
+            + decision.getVerdict());
+
+    System.out.println(
+        "ALL PASS: insecure-TLS production guard verified end-to-end against the live agent");
+  }
+}

--- a/src/main/java/com/getaxonflow/sdk/util/HttpClientFactory.java
+++ b/src/main/java/com/getaxonflow/sdk/util/HttpClientFactory.java
@@ -18,6 +18,8 @@ package com.getaxonflow.sdk.util;
 import com.getaxonflow.sdk.AxonFlowConfig;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
+import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -39,6 +41,50 @@ public final class HttpClientFactory {
    * code is not sufficient to silently disable TLS validation in production environments.
    */
   static final String INSECURE_TLS_ENV_VAR = "AXONFLOW_INSECURE_TLS";
+
+  /**
+   * Common deployment-environment variables inspected by {@link #detectedProductionEnvSignal()}. If
+   * any is set to a production token ({@code "prod"}/{@code "production"}, case-insensitive), the
+   * insecure TLS path is refused outright as a hard production guard, even when both {@code
+   * insecureSkipVerify(true)} and {@value #INSECURE_TLS_ENV_VAR} are set. This is
+   * belt-and-suspenders on top of the existing double-gate: the trust-all path is a
+   * development-only escape hatch for self-signed certificates and must never run in production,
+   * even by operator error.
+   */
+  private static final String[] DEPLOYMENT_ENV_VARS = {
+    "AXONFLOW_ENVIRONMENT",
+    "AXONFLOW_ENV",
+    "ENVIRONMENT",
+    "APP_ENV",
+    "APPLICATION_ENV",
+    "DEPLOY_ENV",
+    "DEPLOYMENT_ENV",
+    "STAGE",
+    "SPRING_PROFILES_ACTIVE",
+    "NODE_ENV",
+    "RAILS_ENV",
+    "RACK_ENV",
+    "DJANGO_ENV",
+    "FLASK_ENV",
+    "ASPNETCORE_ENVIRONMENT",
+  };
+
+  /**
+   * Token delimiters used to split a deployment-environment variable's value before matching
+   * production tokens. Includes whitespace, comma/semicolon/colon (e.g. {@code
+   * SPRING_PROFILES_ACTIVE=prod,metrics}) AND hyphen/underscore/dot/slash so common compound names
+   * such as {@code production-us}, {@code prod_west} or {@code us/east/prod} are tokenised
+   * correctly.
+   */
+  private static final String ENV_VALUE_TOKEN_DELIMITERS = "[\\s,;:._/-]+";
+
+  /**
+   * Tokens that, when they immediately precede a {@code prod}/{@code production} token, negate it
+   * so the guard does NOT trip. This keeps non-production labels such as {@code non-prod}, {@code
+   * not-prod} and {@code pre-prod} (which tokenise to {@code [non, prod]} etc.) usable with the
+   * development escape hatch.
+   */
+  private static final Set<String> NEGATION_PREFIXES = Set.of("non", "not", "pre", "no");
 
   private HttpClientFactory() {
     // Utility class
@@ -65,7 +111,23 @@ public final class HttpClientFactory {
 
     if (config.isInsecureSkipVerify()) {
       if (isInsecureTlsEnvVarEnabled()) {
-        configureInsecureSsl(builder);
+        String productionSignal = detectedProductionEnvSignal();
+        if (productionSignal != null) {
+          // Hard production guard: refuse to disable TLS verification when a production-like
+          // deployment environment is detected, even though both gates were set. Keep the default
+          // (verifying) TrustManager in place.
+          logger.error(
+              "*** SECURITY *** insecureSkipVerify(true) and {}=true were both set, but a "
+                  + "production-like deployment environment was detected ({}). REFUSING to disable "
+                  + "TLS certificate verification. The insecure trust-all path is a development-only "
+                  + "escape hatch for self-signed certificates and MUST NOT run in production. TLS "
+                  + "certificate verification REMAINS ENABLED. Unset the production environment "
+                  + "signal (or run against a non-production environment) to use insecureSkipVerify.",
+              INSECURE_TLS_ENV_VAR,
+              productionSignal);
+        } else {
+          configureInsecureSsl(builder);
+        }
       } else {
         logger.warn(
             "insecureSkipVerify(true) was set on AxonFlowConfig but environment variable {} is "
@@ -156,5 +218,51 @@ public final class HttpClientFactory {
       return false;
     }
     return "true".equalsIgnoreCase(value) || "1".equals(value);
+  }
+
+  /**
+   * Returns a human-readable {@code "VAR=value"} description of the first {@link
+   * #DEPLOYMENT_ENV_VARS deployment environment variable} that signals a production-like
+   * environment, or {@code null} if none do.
+   *
+   * <p>A variable signals production when any token of its value (split on whitespace, comma,
+   * semicolon, colon, hyphen, underscore, dot or slash) equals (case-insensitively) {@code "prod"}
+   * or {@code "production"}. Tokenising on those delimiters handles compound settings such as
+   * {@code SPRING_PROFILES_ACTIVE=prod,metrics} and {@code ENVIRONMENT=production-us}. A {@code
+   * prod}/{@code production} token immediately preceded by a {@link #NEGATION_PREFIXES negation
+   * prefix} (for example {@code non-prod} or {@code pre-prod}) does NOT count, so non-production
+   * labels remain usable with the development escape hatch.
+   *
+   * <p>Package-private to allow test verification.
+   */
+  static String detectedProductionEnvSignal() {
+    for (String var : DEPLOYMENT_ENV_VARS) {
+      String value = System.getenv(var);
+      if (value == null || value.isEmpty()) {
+        continue;
+      }
+      String[] tokens = value.toLowerCase(Locale.ROOT).split(ENV_VALUE_TOKEN_DELIMITERS);
+      for (int i = 0; i < tokens.length; i++) {
+        if (!tokens[i].equals("prod") && !tokens[i].equals("production")) {
+          continue;
+        }
+        if (i > 0 && NEGATION_PREFIXES.contains(tokens[i - 1])) {
+          // Negated form such as non-prod / pre-prod: not a production signal.
+          continue;
+        }
+        return var + "=" + value;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns {@code true} if any common deployment environment variable signals a production-like
+   * environment. Used as a hard production guard: even when both {@code insecureSkipVerify(true)}
+   * and {@value #INSECURE_TLS_ENV_VAR} are set, TLS certificate verification is NOT disabled in a
+   * production-like environment. Package-private to allow test verification.
+   */
+  static boolean isProductionLikeEnvironment() {
+    return detectedProductionEnvSignal() != null;
   }
 }

--- a/src/test/java/com/getaxonflow/sdk/util/HttpClientFactoryTest.java
+++ b/src/test/java/com/getaxonflow/sdk/util/HttpClientFactoryTest.java
@@ -130,7 +130,10 @@ class HttpClientFactoryTest {
     // (covered by sibling tests). If either gate stops being required, this test will still
     // pass — the gating behaviour is asserted in the negative-path tests.
     AxonFlowConfig config =
-        AxonFlowConfig.builder().agentUrl("https://localhost:8080").insecureSkipVerify(true).build();
+        AxonFlowConfig.builder()
+            .agentUrl("https://localhost:8080")
+            .insecureSkipVerify(true)
+            .build();
 
     OkHttpClient client = HttpClientFactory.create(config);
 
@@ -168,8 +171,7 @@ class HttpClientFactoryTest {
     // Complementary negative path: env var alone, without insecureSkipVerify(true), must
     // keep the default safe TrustManager and OkHostnameVerifier. The double-gate is symmetric:
     // BOTH must be present — neither alone activates the insecure path.
-    AxonFlowConfig config =
-        AxonFlowConfig.builder().agentUrl("https://localhost:8080").build();
+    AxonFlowConfig config = AxonFlowConfig.builder().agentUrl("https://localhost:8080").build();
 
     OkHttpClient client = HttpClientFactory.create(config);
 
@@ -177,5 +179,123 @@ class HttpClientFactoryTest {
     assertThat(client.hostnameVerifier().getClass().getName())
         .as("default hostname verifier must remain when only env var is set")
         .contains("OkHostnameVerifier");
+  }
+
+  @Test
+  @DisplayName(
+      "should REFUSE the insecure TLS path when both gates are set but a production environment "
+          + "is detected (hard production guard)")
+  @SetEnvironmentVariable(key = "AXONFLOW_INSECURE_TLS", value = "true")
+  @SetEnvironmentVariable(key = "ENVIRONMENT", value = "production")
+  void shouldRefuseInsecurePathInProductionEnvironment() {
+    // Belt-and-suspenders: even with BOTH insecureSkipVerify(true) AND AXONFLOW_INSECURE_TLS=true,
+    // a production-like deployment environment must hard-refuse the trust-all path. This asserts
+    // the guard actually PREVENTS the insecure path (not merely logs): the default verifying
+    // hostname verifier MUST remain installed.
+    AxonFlowConfig config =
+        AxonFlowConfig.builder()
+            .agentUrl("https://localhost:8080")
+            .insecureSkipVerify(true)
+            .build();
+
+    OkHttpClient client = HttpClientFactory.create(config);
+
+    assertThat(client).isNotNull();
+
+    // Definitive proof the insecure path was refused: the insecure path installs the permissive
+    // `(hostname, session) -> true` verifier (a synthetic lambda whose class name does NOT contain
+    // "OkHostnameVerifier"). Seeing OkHttp's default verifier means the trust-all path never ran.
+    assertThat(client.hostnameVerifier().getClass().getName())
+        .as(
+            "production guard must keep the default verifying hostname verifier, refusing trust-all")
+        .contains("OkHostnameVerifier");
+
+    // Parity with a plain default client: the guard must leave the SAME verifier type in place as a
+    // config that never requested insecureSkipVerify at all. (OkHttp lazily builds a fresh default
+    // SSLSocketFactory per client, so the socket-factory instances are NOT identity-equal even on
+    // the safe path; the verifier type is the stable, meaningful signal here.)
+    AxonFlowConfig defaultConfig =
+        AxonFlowConfig.builder().agentUrl("https://localhost:8080").build();
+    OkHttpClient defaultClient = HttpClientFactory.create(defaultConfig);
+    assertThat(client.hostnameVerifier().getClass())
+        .as("production guard must leave the default verifier type in place")
+        .isEqualTo(defaultClient.hostnameVerifier().getClass());
+  }
+
+  @Test
+  @DisplayName("production-guard helper should be false in a clean (non-production) environment")
+  void productionGuardShouldBeFalseByDefault() {
+    // The standard CI/dev shell sets none of the inspected deployment env vars to a production
+    // token; if this fails, the test environment is mislabelled as production.
+    assertThat(HttpClientFactory.isProductionLikeEnvironment())
+        .as("no production signal should be present in a clean test environment")
+        .isFalse();
+    assertThat(HttpClientFactory.detectedProductionEnvSignal()).isNull();
+  }
+
+  @Test
+  @DisplayName("production-guard helper should detect ENVIRONMENT=production")
+  @SetEnvironmentVariable(key = "ENVIRONMENT", value = "production")
+  void productionGuardShouldDetectEnvironmentProduction() {
+    assertThat(HttpClientFactory.isProductionLikeEnvironment()).isTrue();
+    assertThat(HttpClientFactory.detectedProductionEnvSignal()).isEqualTo("ENVIRONMENT=production");
+  }
+
+  @Test
+  @DisplayName(
+      "production-guard helper should detect a compound SPRING_PROFILES_ACTIVE=prod,metrics")
+  @SetEnvironmentVariable(key = "SPRING_PROFILES_ACTIVE", value = "prod,metrics")
+  void productionGuardShouldDetectCompoundSpringProfile() {
+    // Compound, delimiter-separated values must be tokenised so a 'prod' token is still caught.
+    assertThat(HttpClientFactory.isProductionLikeEnvironment()).isTrue();
+    assertThat(HttpClientFactory.detectedProductionEnvSignal())
+        .isEqualTo("SPRING_PROFILES_ACTIVE=prod,metrics");
+  }
+
+  @Test
+  @DisplayName("production-guard helper should NOT trip on a non-production value")
+  @SetEnvironmentVariable(key = "ENVIRONMENT", value = "development")
+  void productionGuardShouldNotTripOnNonProductionValue() {
+    // A non-production environment must still allow the development escape hatch: the guard must
+    // not false-positive on substrings like 'reproduction' or unrelated values.
+    assertThat(HttpClientFactory.isProductionLikeEnvironment()).isFalse();
+    assertThat(HttpClientFactory.detectedProductionEnvSignal()).isNull();
+  }
+
+  @Test
+  @DisplayName("production-guard helper should detect a hyphen-delimited ENVIRONMENT=production-us")
+  @SetEnvironmentVariable(key = "ENVIRONMENT", value = "production-us")
+  void productionGuardShouldDetectHyphenDelimitedProductionName() {
+    // AxonFlow's own deployments use hyphen-delimited names like 'axonflow-production-us'; the
+    // tokeniser must split on '-' so the embedded production token is caught.
+    assertThat(HttpClientFactory.isProductionLikeEnvironment()).isTrue();
+    assertThat(HttpClientFactory.detectedProductionEnvSignal())
+        .isEqualTo("ENVIRONMENT=production-us");
+  }
+
+  @Test
+  @DisplayName("production-guard helper should detect an underscore-delimited APP_ENV=prod_west")
+  @SetEnvironmentVariable(key = "APP_ENV", value = "prod_west")
+  void productionGuardShouldDetectUnderscoreDelimitedProdName() {
+    assertThat(HttpClientFactory.isProductionLikeEnvironment()).isTrue();
+    assertThat(HttpClientFactory.detectedProductionEnvSignal()).isEqualTo("APP_ENV=prod_west");
+  }
+
+  @Test
+  @DisplayName("production-guard helper should NOT trip on a negated ENVIRONMENT=non-prod")
+  @SetEnvironmentVariable(key = "ENVIRONMENT", value = "non-prod")
+  void productionGuardShouldNotTripOnNegatedNonProd() {
+    // 'non-prod' tokenises to [non, prod]; the 'non' negation prefix must keep the development
+    // escape hatch usable in a non-production environment.
+    assertThat(HttpClientFactory.isProductionLikeEnvironment()).isFalse();
+    assertThat(HttpClientFactory.detectedProductionEnvSignal()).isNull();
+  }
+
+  @Test
+  @DisplayName("production-guard helper should NOT trip on a negated SPRING profile pre-prod")
+  @SetEnvironmentVariable(key = "SPRING_PROFILES_ACTIVE", value = "pre-prod,metrics")
+  void productionGuardShouldNotTripOnNegatedPreProd() {
+    assertThat(HttpClientFactory.isProductionLikeEnvironment()).isFalse();
+    assertThat(HttpClientFactory.detectedProductionEnvSignal()).isNull();
   }
 }


### PR DESCRIPTION
## Summary
Clears all three open security alerts on this repo (epic getaxonflow/axonflow-enterprise#2711).

| Alert | Sev | What | Fix |
|-------|-----|------|-----|
| CodeQL #8 | high | `java/insecure-trustmanager` at `HttpClientFactory.java` | hard production guard added (see below); alert dismissed-by-design |
| CodeQL #9 | medium | `actions/missing-workflow-permissions` on `heartbeat-real-stack.yml` | top-level `permissions: contents: read` |
| Dependabot #2 | medium | example pins stale `com.getaxonflow:axonflow-sdk` `5.5.0` (vuln `< 6.0.0`) | `examples/wcp-retry-idempotency/pom.xml` -> `8.5.0` |

## CodeQL #8: keep the dev escape hatch, add a hard production guard
The trust-all `TrustManager` is an **intentional, double-gated** development affordance for self-signed certificates: it activates only when BOTH `insecureSkipVerify(true)` is set on the config builder AND the `AXONFLOW_INSECURE_TLS` env var is set. Removing it would break legitimate local self-signed-cert workflows, so it stays.

As belt-and-suspenders, `create()` now **refuses** the insecure path entirely when a production-like deployment environment is detected, even if both gates are set: TLS verification stays on and a `SECURITY` error is logged naming the signalling variable. A production environment is detected when any of a set of common deployment env vars (`ENVIRONMENT`, `AXONFLOW_ENVIRONMENT`, `APP_ENV`, `SPRING_PROFILES_ACTIVE`, `NODE_ENV`, ...) carries a `prod`/`production` token. The value is tokenised on whitespace/comma/semicolon/colon/hyphen/underscore/dot/slash so compound names like `production-us` and `prod_west` are caught; negated labels like `non-prod`/`pre-prod` are correctly **not** treated as production so the dev hatch stays usable there.

New unit tests prove the guard **prevents** (not merely logs) the insecure path, catches hyphen/underscore-delimited prod names, handles compound Spring profiles, and does not false-positive on negated or non-prod values.

Because this is a real shipped-code change, `pom.xml` is bumped `8.5.0` -> `8.5.1` with a matching `CHANGELOG` entry. (No tag is cut here; release is the operator's step.) The CodeQL alert will be dismissed-by-design on the epic now that the production path is hardened.

## Workflow permissions
`heartbeat-real-stack.yml` only checks out the repo and runs tests, so `contents: read` is sufficient. Block kept **byte-identical** to the axonflow-sdk-typescript heartbeat fix.

## Example SDK bump
`examples/wcp-retry-idempotency/pom.xml` referenced the long-stale `5.5.0`; bumped to the current released `8.5.0` on Maven Central (>= the `6.0.0` patch floor). The example is a standalone module (not in the parent `<modules>`); it intentionally references the last published release, not the unreleased `8.5.1`.

## Tests
- `mvn test` green (1312 tests, 0 failures; 18 in `HttpClientFactoryTest`)
- `mvn jacoco:check` green (coverage gate met)

Refs getaxonflow/axonflow-enterprise#2711

## Runtime E2E
Added `runtime-e2e/trustmanager_prod_guard/` (no-mocks Java driver + README) proving the guard end-to-end against a live agent: in a production-like env with insecure TLS requested, the SDK refuses the trust-all path (default verifying verifier stays installed) yet a real governed `decide()` still succeeds over the agent's valid TLS cert. Compiles against the real SDK API; run instructions in the README.
