### PR TITLE
fix(examples): basic reads AXONFLOW_USER_TOKEN; async parity e2e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the AxonFlow Java SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Hostile-testing sweep ahead of the BukuWarung integration
+(getaxonflow/axonflow-enterprise#2861). Examples + runtime-e2e only — no
+library changes.
+
+### Fixed
+
+- **`examples/basic` passes on enterprise (JWT-validating) stacks.** It
+  omitted the user token entirely (SDK falls back to `anonymous`), which
+  `DEPLOYMENT_MODE=enterprise` rejects — and the rejection was swallowed by
+  the generic `AxonFlowException` catch with exit 0. The example now reads
+  `AXONFLOW_USER_TOKEN` and exits non-zero on invalid-user-token rejections.
+
+### Added
+
+- `runtime-e2e/async_verdict_parity/` — live-agent assertion that
+  `decideAsync`/`mcpCheckInputAsync` (joined) deliver the same enforcement
+  verdict as their sync counterparts (async-adapter-bypass class): stacked
+  SQLi → `deny` on `/api/v1/decide`, `allowed=false` on check-input, sync ==
+  async on both planes.
+
 ## [8.5.1] - 2026-06-16: TLS security hardening (production guard)
 
 Patch release. No public API changes.

--- a/examples/basic/src/main/java/com/getaxonflow/examples/Basic.java
+++ b/examples/basic/src/main/java/com/getaxonflow/examples/Basic.java
@@ -88,15 +88,20 @@ public class Basic {
         System.out.println("Step 2: Protected proxyLLMCall");
         System.out.println("============================================================");
         try {
-            // Don't set userToken — the SDK auto-populates it from clientId
-            // when omitted. Sending a literal "demo-user" string is rejected
-            // by the agent's JWT middleware on stacks with token validation.
-            ClientRequest request =
+            // Enterprise stacks (DEPLOYMENT_MODE=enterprise) validate user
+            // tokens as JWTs — export AXONFLOW_USER_TOKEN (see
+            // scripts/generate-jwt.sh in the platform repo). Community
+            // stacks skip JWT validation, so omitting it is fine there.
+            String userToken = System.getenv("AXONFLOW_USER_TOKEN");
+            ClientRequest.Builder requestBuilder =
                     ClientRequest.builder()
                             .query("What is the capital of France?")
                             .clientId(clientId)
-                            .requestType(RequestType.CHAT)
-                            .build();
+                            .requestType(RequestType.CHAT);
+            if (userToken != null && !userToken.isEmpty()) {
+                requestBuilder.userToken(userToken);
+            }
+            ClientRequest request = requestBuilder.build();
 
             ClientResponse response = client.proxyLLMCall(request);
             System.out.printf("  Success: %s%n", response.isSuccess());
@@ -110,10 +115,15 @@ public class Basic {
             System.err.println("proxyLLMCall failed: " + e.getMessage());
             System.exit(1);
         } catch (AxonFlowException e) {
-            // Other SDK-level failures (e.g. agent returns non-2xx because
-            // no LLM provider is configured) — log and continue. Tightening
-            // this further requires capability detection from /health,
-            // tracked in axonflow-sdk-java#146.
+            // Invalid-user-token rejections are real failures (export
+            // AXONFLOW_USER_TOKEN on JWT-validating stacks). Other
+            // SDK-level failures (e.g. no LLM provider configured) — log
+            // and continue; tightening further requires capability
+            // detection from /health, tracked in axonflow-sdk-java#146.
+            if (e.getMessage() != null && e.getMessage().contains("Invalid user token")) {
+                System.err.println("proxyLLMCall failed: " + e.getMessage());
+                System.exit(1);
+            }
             System.out.println("  proxyLLMCall non-success: " + e.getMessage());
         }
     }

--- a/examples/basic/src/main/java/com/getaxonflow/examples/Basic.java
+++ b/examples/basic/src/main/java/com/getaxonflow/examples/Basic.java
@@ -115,13 +115,18 @@ public class Basic {
             System.err.println("proxyLLMCall failed: " + e.getMessage());
             System.exit(1);
         } catch (AxonFlowException e) {
-            // Invalid-user-token rejections are real failures (export
-            // AXONFLOW_USER_TOKEN on JWT-validating stacks). Other
-            // SDK-level failures (e.g. no LLM provider configured) — log
-            // and continue; tightening further requires capability
-            // detection from /health, tracked in axonflow-sdk-java#146.
-            if (e.getMessage() != null && e.getMessage().contains("Invalid user token")) {
-                System.err.println("proxyLLMCall failed: " + e.getMessage());
+            // Auth/token rejections are real failures (export AXONFLOW_USER_TOKEN
+            // on JWT-validating stacks). Match on any auth-rejection phrasing
+            // (case-insensitive) rather than one exact string, so a
+            // differently-worded rejection isn't silently swallowed. Non-auth
+            // SDK failures (e.g. "no LLM provider configured") — log and
+            // continue; fully distinguishing them needs /health capability
+            // detection, tracked in axonflow-sdk-java#146.
+            String msg = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
+            if (msg.contains("token") || msg.contains("unauthorized")
+                    || msg.contains("authentication") || msg.contains("jwt")
+                    || msg.contains("credential")) {
+                System.err.println("proxyLLMCall failed (auth): " + e.getMessage());
                 System.exit(1);
             }
             System.out.println("  proxyLLMCall non-success: " + e.getMessage());

--- a/runtime-e2e/async_verdict_parity/AsyncVerdictParityTest.java
+++ b/runtime-e2e/async_verdict_parity/AsyncVerdictParityTest.java
@@ -1,0 +1,96 @@
+/*
+ * runtime-e2e/async_verdict_parity/AsyncVerdictParityTest.java
+ *
+ * Real-stack assertion: the async client variants deliver the SAME
+ * enforcement verdict as their sync counterparts (async-adapter-bypass
+ * class, getaxonflow/axonflow-enterprise#2861).
+ *
+ * Per runtime-e2e/README.md this test runs a real JVM + built SDK jar
+ * against a real AxonFlow agent — no mocks.
+ *
+ * The Java SDK's *Async methods wrap the sync call in
+ * CompletableFuture.supplyAsync(...): the enforcement verdict (or
+ * exception) materializes INSIDE the future. This test proves that a
+ * caller who joins the future observes identical enforcement to the sync
+ * path, for both the Decision Mode PDP (deny verdict for a stacked-SQLi
+ * LLM stage) and the MCP check plane (allowed=false). The residual
+ * caller-side hazard — never joining the future — is documented in the
+ * method javadocs; the SDK itself never leaves a governance future
+ * unjoined.
+ *
+ * Run (after `source /tmp/axonflow-e2e-env.sh` from the enterprise setup
+ * script and `mvn install -DskipTests`):
+ *
+ *   mvn -q dependency:build-classpath -Dmdep.outputFile=/tmp/cp.txt
+ *   SDK_JAR=$(ls target/axonflow-sdk-*.jar | grep -v sources | grep -v javadoc | head -1)
+ *   java -cp "$SDK_JAR:$(cat /tmp/cp.txt)" \
+ *     runtime-e2e/async_verdict_parity/AsyncVerdictParityTest.java
+ */
+import com.getaxonflow.sdk.AxonFlow;
+import com.getaxonflow.sdk.AxonFlowConfig;
+import com.getaxonflow.sdk.types.DecideRequest;
+import com.getaxonflow.sdk.types.DecideResponse;
+import com.getaxonflow.sdk.types.DecisionTarget;
+import com.getaxonflow.sdk.types.MCPCheckInputResponse;
+
+public class AsyncVerdictParityTest {
+
+  static final String SQLI = "SELECT * FROM users WHERE 1=1; DROP TABLE users;--";
+
+  static void fail(String msg) {
+    System.err.println("FAIL: " + msg);
+    System.exit(1);
+  }
+
+  static void check(boolean cond, String msg) {
+    if (!cond) {
+      fail(msg);
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    String endpoint = System.getenv().getOrDefault("AXONFLOW_ENDPOINT", "http://localhost:8080");
+    String clientId = System.getenv("AXONFLOW_CLIENT_ID");
+    String clientSecret = System.getenv("AXONFLOW_CLIENT_SECRET");
+    if (clientId == null || clientSecret == null) {
+      fail("AXONFLOW_CLIENT_ID and AXONFLOW_CLIENT_SECRET must be set");
+    }
+
+    AxonFlow client =
+        AxonFlow.create(
+            AxonFlowConfig.builder()
+                .endpoint(endpoint)
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .build());
+
+    // 1. Decision Mode: sync vs joined-async verdict parity on a deny.
+    DecideRequest req =
+        DecideRequest.builder("llm", SQLI)
+            .target(new DecisionTarget("llm", "gpt-4", "openai", null))
+            .build();
+
+    DecideResponse syncResp = client.decide(req);
+    DecideResponse asyncResp = client.decideAsync(req).join();
+    check(
+        syncResp.getVerdict().equals(asyncResp.getVerdict()),
+        "decide verdict mismatch: sync=" + syncResp.getVerdict()
+            + " async=" + asyncResp.getVerdict());
+    check(
+        "deny".equals(syncResp.getVerdict()),
+        "expected deny for stacked SQLi at llm stage, got " + syncResp.getVerdict());
+    System.out.println("PASS [decide-parity] sync=async verdict=" + syncResp.getVerdict());
+
+    // 2. MCP check plane: sync vs joined-async allowed parity on a block.
+    MCPCheckInputResponse syncCheck = client.mcpCheckInput("postgres", SQLI);
+    MCPCheckInputResponse asyncCheck = client.mcpCheckInputAsync("postgres", SQLI).join();
+    check(
+        syncCheck.isAllowed() == asyncCheck.isAllowed(),
+        "mcpCheckInput allowed mismatch: sync=" + syncCheck.isAllowed()
+            + " async=" + asyncCheck.isAllowed());
+    check(!syncCheck.isAllowed(), "expected stacked SQLi to be blocked on check-input");
+    System.out.println("PASS [check-input-parity] sync=async allowed=" + syncCheck.isAllowed());
+
+    System.out.println("RESULT: PASS (2/2)");
+  }
+}


### PR DESCRIPTION
## Summary

Hostile-testing sweep TEST-SDK ahead of the BukuWarung integration — tracking getaxonflow/axonflow-enterprise#2861. Examples + runtime-e2e only; no library changes.

- **`examples/basic` failed on enterprise (JWT-validating) stacks and hid it.** It sent no user token (SDK falls back to `anonymous`), the agent rejected it with "Invalid user token", and the generic `AxonFlowException` catch printed "non-success" and exited 0. Now reads `AXONFLOW_USER_TOKEN` (community stacks still work with it unset) and exits non-zero on invalid-user-token rejections.
- **New `runtime-e2e/async_verdict_parity/`** — the async-adapter-bypass check for Java: `decideAsync(...).join()` and `mcpCheckInputAsync(...).join()` must deliver identical enforcement to the sync calls. Against a live enterprise stack (v9.6.1): stacked SQLi → `verdict=deny` on `/api/v1/decide` and `allowed=false` on check-input, sync == async on both planes — PASS 2/2. (The Java SDK's `*Async` methods wrap sync calls in `CompletableFuture.supplyAsync`; the SDK never leaves a governance future unjoined — the caller-side never-join hazard is noted in the test header.)

## Testing

- `examples/basic` re-run green against a live enterprise stack: health check + `proxyLLMCall` real LLM round-trip (`Success: true`) + connector listing, exit 0.
- `runtime-e2e/async_verdict_parity/AsyncVerdictParityTest.java` PASS 2/2 against the live stack (run log in the test header format).
- Other examples (explain-decision, list-decisions, wcp-retry-idempotency) already green — re-verified this sweep.

## Related Issues

- getaxonflow/axonflow-enterprise#2861