### PR TITLE
fix(examples): pin poms to published 9.0.0; fail loud on tenant mismatch [skip-runtime-e2e]

### DIFF
--- a/examples/basic/pom.xml
+++ b/examples/basic/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>6.1.0</version>
+            <version>8.5.1</version>
         </dependency>
     </dependencies>
 

--- a/examples/basic/pom.xml
+++ b/examples/basic/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.5.1</version>
+            <version>9.0.0</version>
         </dependency>
     </dependencies>
 

--- a/examples/basic/src/main/java/com/getaxonflow/examples/Basic.java
+++ b/examples/basic/src/main/java/com/getaxonflow/examples/Basic.java
@@ -107,7 +107,7 @@ public class Basic {
             System.out.printf("  Success: %s%n", response.isSuccess());
             System.out.printf("  Blocked: %s%n", response.isBlocked());
         } catch (PolicyViolationException e) {
-            // SDK <= 8.5.1 misclassifies 403 auth rejections as policy
+            // SDK <= 9.0.0 misclassifies 403 auth rejections as policy
             // violations: every agent error body carries a literal
             // "blocked":false key, which trips handleErrorResponse's
             // body.contains("blocked") heuristic. Until the library fix

--- a/examples/basic/src/main/java/com/getaxonflow/examples/Basic.java
+++ b/examples/basic/src/main/java/com/getaxonflow/examples/Basic.java
@@ -107,8 +107,20 @@ public class Basic {
             System.out.printf("  Success: %s%n", response.isSuccess());
             System.out.printf("  Blocked: %s%n", response.isBlocked());
         } catch (PolicyViolationException e) {
-            // Policy block is a valid outcome — community policies can match
-            // the demo query depending on configuration.
+            // SDK <= 8.5.1 misclassifies 403 auth rejections as policy
+            // violations: every agent error body carries a literal
+            // "blocked":false key, which trips handleErrorResponse's
+            // body.contains("blocked") heuristic. Until the library fix
+            // ships, treat tenant mismatch as the auth failure it is —
+            // otherwise a wrong AXONFLOW_CLIENT_ID (it must match the
+            // user token's tenant) sails through the smoke with exit 0.
+            if (e.getMessage() != null && e.getMessage().contains("Tenant mismatch")) {
+                System.err.println("proxyLLMCall failed (auth): " + e.getMessage()
+                        + " — AXONFLOW_CLIENT_ID must match the user token's tenant");
+                System.exit(1);
+            }
+            // Genuine policy block is a valid outcome — community policies
+            // can match the demo query depending on configuration.
             System.out.printf("  Blocked by policy: %s%n", e.getMessage());
         } catch (AuthenticationException | ConnectionException e) {
             // These are real failures: bad creds or stack down. Fail loud.

--- a/examples/explain-decision/pom.xml
+++ b/examples/explain-decision/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.5.0</version>
+            <version>8.5.1</version>
         </dependency>
     </dependencies>
 

--- a/examples/explain-decision/pom.xml
+++ b/examples/explain-decision/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.5.1</version>
+            <version>9.0.0</version>
         </dependency>
     </dependencies>
 

--- a/examples/list-decisions/pom.xml
+++ b/examples/list-decisions/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.5.0</version>
+            <version>8.5.1</version>
         </dependency>
     </dependencies>
 

--- a/examples/list-decisions/pom.xml
+++ b/examples/list-decisions/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.5.1</version>
+            <version>9.0.0</version>
         </dependency>
     </dependencies>
 

--- a/examples/wcp-retry-idempotency/pom.xml
+++ b/examples/wcp-retry-idempotency/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.5.0</version>
+            <version>8.5.1</version>
         </dependency>
     </dependencies>
 

--- a/examples/wcp-retry-idempotency/pom.xml
+++ b/examples/wcp-retry-idempotency/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.5.1</version>
+            <version>9.0.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Follow-up to #194 (merged mid-smoke) from the release-readiness gate for getaxonflow/axonflow-enterprise#2861 - Java SDK examples smoke-tested against a live enterprise stack (platform v9.6.1), pins since refreshed to the current published artifact.

## What

- **Pin all four example poms to the published SDK 9.0.0.** `basic` pinned 6.1.0 and the other three pinned 8.5.0, so smoke runs resolved stale remote Maven artifacts. Originally pinned to 8.5.1; refreshed in-flight because Maven Central now serves **9.0.0** (released 2026-07-18, `com.getaxonflow:axonflow-sdk` latest = release = 9.0.0). The 9.0.0 breaking change is confined to the LangGraph MCP adapter (`connector_type`/`tool` split), which none of the four examples touch; all four build clean against the published 9.0.0 jar resolved from Central into a fresh local repository.
- **`basic`: fail loud on tenant-mismatch 403.** The agent's 403 error body carries a literal `"blocked":false` key (`ClientResponse.Blocked` has no `omitempty`, verified at platform v9.13.0), which trips the SDK's `handleErrorResponse` `body.contains("blocked")` heuristic and misclassifies the auth rejection as `PolicyViolationException` - the example then printed `Blocked by policy: Tenant mismatch` and exited 0 (same swallowed-auth class #194 fixed for 401s). The heuristic is still present in the published 9.0.0 (checked in the v9.0.0 tag and reproduced against the published jar), so until the library fix (#197) ships, the example treats a `Tenant mismatch` message as an auth failure and exits 1 with a pointer to the client-id/user-token tenant pairing requirement.

## Library follow-up (not in this PR - examples-only)

`AxonFlow.handleErrorResponse` should only map a 403 to `PolicyViolationException` when the body actually signals a block (e.g. `"blocked":true`), not on a bare `blocked` substring that matches every error envelope. Tracked as #197.

## Testing

Original round (live enterprise stack, platform v9.6.1): all four examples (`basic`, `explain-decision`, `list-decisions`, `wcp-retry-idempotency`) exit 0 with meaningful output under the stack's canonical tenant identity, including a real LLM round-trip, a stacked-SQLi `sys_sqli_stacked_drop` block explained end-to-end, and the full WCP retry/idempotency assertion suite. Negative test: `basic` run with a client id that does not match the user token's tenant exits 1 with `proxyLLMCall failed (auth): ... Tenant mismatch`.

9.0.0 refresh round (published artifact from Maven Central, fresh local repo, stub agent emitting the exact v9.13.0 `sendErrorResponse`/`ClientResponse` wire shapes):
- All four examples `mvn package` clean against the published 9.0.0 jar.
- Discriminating run: 403 `{"success":false,"error":"Tenant mismatch","blocked":false}` -> `basic` exits 1 with `proxyLLMCall failed (auth): ...` (and the exception observed is `PolicyViolationException`, proving published 9.0.0 still misclassifies).
- Control run: 403 `{"success":false,"error":"Blocked by policy: sys_sqli_stacked_drop","blocked":true}` -> prints `Blocked by policy: ...`, continues, exits 0.
- Mutation run: with the fail-loud hunk reverted to the pre-PR catch block, the same tenant-mismatch response prints `Blocked by policy: ... Tenant mismatch` and exits 0 - the exact swallowed-auth failure this PR pins. Hunk restored after the run.

## Skip-runtime-e2e justification

Examples-only change - no `src/main` library code or SDK runtime surface is touched (4 example pom version pins + one example error-handling branch). The examples themselves were exercised end-to-end against a live enterprise stack (platform v9.6.1) plus the stub-agent discrimination/control/mutation runs above against the published 9.0.0 artifact. The SDK surface these examples call is already covered by runtime-e2e (incl. the async verdict-parity leg added in #194).
