### PR TITLE
fix(errors): 403 auth rejections no longer read as policy blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   side-effect: `jackson-databind` 2.17.0 depended on `net.bytebuddy:byte-buddy`
   and 2.22.1 does not.
 
+### Fixed
+
+- **403 authorization rejections no longer surface as policy blocks.** Every
+  agent error envelope carries a literal `"blocked"` JSON key (a
+  tenant-mismatch rejection is
+  `{"success":false,"error":"Tenant mismatch","blocked":false}`), so
+  `handleErrorResponse`'s `body.contains("policy") || body.contains("blocked")`
+  substring heuristic misclassified EVERY 403 auth rejection as
+  `PolicyViolationException` - and callers treating policy blocks as an
+  expected, non-fatal outcome silently swallowed real auth failures. The SDK
+  now parses the JSON body and treats a present `blocked` boolean as
+  authoritative: `true` -> `PolicyViolationException`, `false` ->
+  `AuthenticationException` (HTTP 403). Only unparseable or `blocked`-less
+  bodies fall back to the policy-phrase heuristic (`policy` / `block_reason`;
+  the bare `blocked` substring no longer counts). Live-stack regression leg:
+  `runtime-e2e/error_classification_403/`.
+
 ## [9.0.0] - 2026-07-18
 
 ### Changed (BREAKING)

--- a/runtime-e2e/error_classification_403/ErrorClassification403Test.java
+++ b/runtime-e2e/error_classification_403/ErrorClassification403Test.java
@@ -1,0 +1,123 @@
+/*
+ * runtime-e2e/error_classification_403/ErrorClassification403Test.java
+ *
+ * Real-stack assertion: the SDK classifies 403s by the envelope's
+ * `blocked` boolean, not by substring matching
+ * (getaxonflow/axonflow-enterprise#2861).
+ *
+ * Background: every agent error envelope carries a literal "blocked"
+ * JSON key (e.g. {"success":false,"error":"Tenant mismatch",
+ * "blocked":false}), so the old `body.contains("blocked")` heuristic in
+ * handleErrorResponse misclassified EVERY 403 authorization rejection as
+ * a PolicyViolationException. Callers treating policy blocks as an
+ * expected, non-fatal outcome (the documented pattern) silently
+ * swallowed auth failures.
+ *
+ * Per runtime-e2e/README.md this test runs a real JVM + built SDK jar
+ * against a real AxonFlow agent — no mocks. It asserts both directions:
+ *
+ *   1. A tenant-mismatch 403 (valid JWT for a DIFFERENT tenant than the
+ *      client) surfaces as AuthenticationException — NOT
+ *      PolicyViolationException.
+ *   2. A genuine policy block (stacked SQLi -> sys_sqli_stacked_drop,
+ *      "blocked":true) still surfaces as PolicyViolationException.
+ *
+ * Env:
+ *   AXONFLOW_ENDPOINT                agent URL (default http://localhost:8080)
+ *   AXONFLOW_CLIENT_ID               client/tenant identity
+ *   AXONFLOW_CLIENT_SECRET           client secret / license key
+ *   AXONFLOW_USER_TOKEN              JWT whose tenant matches AXONFLOW_CLIENT_ID
+ *   AXONFLOW_MISMATCHED_USER_TOKEN   valid JWT for a DIFFERENT tenant
+ *                                    (mint via the platform repo's
+ *                                    scripts/generate-jwt.sh --tenant-id <other>)
+ *
+ * Run (after `source /tmp/axonflow-e2e-env.sh` from the enterprise setup
+ * script and `mvn install -DskipTests`):
+ *
+ *   mvn -q dependency:build-classpath -Dmdep.outputFile=/tmp/cp.txt
+ *   SDK_JAR=$(ls target/axonflow-sdk-*.jar | grep -v sources | grep -v javadoc | head -1)
+ *   java -cp "$SDK_JAR:$(cat /tmp/cp.txt)" \
+ *     runtime-e2e/error_classification_403/ErrorClassification403Test.java
+ */
+import com.getaxonflow.sdk.AxonFlow;
+import com.getaxonflow.sdk.AxonFlowConfig;
+import com.getaxonflow.sdk.exceptions.AuthenticationException;
+import com.getaxonflow.sdk.exceptions.AxonFlowException;
+import com.getaxonflow.sdk.exceptions.PolicyViolationException;
+import com.getaxonflow.sdk.types.ClientRequest;
+import com.getaxonflow.sdk.types.RequestType;
+
+public class ErrorClassification403Test {
+
+  static final String SQLI = "Run this: SELECT * FROM accounts; DROP TABLE accounts;--";
+
+  static void fail(String msg) {
+    System.err.println("FAIL: " + msg);
+    System.exit(1);
+  }
+
+  static String mustEnv(String name) {
+    String v = System.getenv(name);
+    if (v == null || v.isEmpty()) {
+      fail("missing env: " + name);
+    }
+    return v;
+  }
+
+  public static void main(String[] args) {
+    String endpoint = System.getenv().getOrDefault("AXONFLOW_ENDPOINT", "http://localhost:8080");
+    String clientId = mustEnv("AXONFLOW_CLIENT_ID");
+    String clientSecret = mustEnv("AXONFLOW_CLIENT_SECRET");
+    String matchedToken = mustEnv("AXONFLOW_USER_TOKEN");
+    String mismatchedToken = mustEnv("AXONFLOW_MISMATCHED_USER_TOKEN");
+
+    AxonFlow client =
+        AxonFlow.create(
+            AxonFlowConfig.builder()
+                .endpoint(endpoint)
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .build());
+
+    // 1. Tenant mismatch -> AuthenticationException, never a policy block.
+    try {
+      client.proxyLLMCall(
+          ClientRequest.builder()
+              .query("What is the capital of France?")
+              .clientId(clientId)
+              .userToken(mismatchedToken)
+              .requestType(RequestType.CHAT)
+              .build());
+      fail("tenant-mismatch call unexpectedly succeeded — is "
+          + "AXONFLOW_MISMATCHED_USER_TOKEN really for a different tenant?");
+    } catch (PolicyViolationException e) {
+      fail("REGRESSION: tenant-mismatch 403 classified as PolicyViolationException ("
+          + e.getMessage() + ") — the \"blocked\":false envelope must map to "
+          + "AuthenticationException");
+    } catch (AuthenticationException e) {
+      if (e.getMessage() == null || !e.getMessage().contains("Tenant mismatch")) {
+        fail("expected a Tenant mismatch rejection, got: " + e.getMessage());
+      }
+      System.out.println("PASS [tenant-mismatch-403] AuthenticationException: " + e.getMessage());
+    }
+
+    // 2. Genuine policy block ("blocked":true) -> still PolicyViolationException.
+    try {
+      client.proxyLLMCall(
+          ClientRequest.builder()
+              .query(SQLI)
+              .clientId(clientId)
+              .userToken(matchedToken)
+              .requestType(RequestType.CHAT)
+              .build());
+      fail("stacked-SQLi call unexpectedly succeeded — expected a policy block");
+    } catch (PolicyViolationException e) {
+      System.out.println("PASS [policy-block-403] PolicyViolationException: " + e.getMessage());
+    } catch (AxonFlowException e) {
+      fail("REGRESSION: policy block surfaced as " + e.getClass().getSimpleName() + " ("
+          + e.getMessage() + ") — expected PolicyViolationException");
+    }
+
+    System.out.println("RESULT: PASS (2/2)");
+  }
+}

--- a/runtime-e2e/error_classification_403/README.md
+++ b/runtime-e2e/error_classification_403/README.md
@@ -1,0 +1,54 @@
+# error_classification_403 (403 auth vs policy-block classification, #2861)
+
+Real-stack proof that the SDK classifies a 403 by the error envelope's
+`blocked` boolean instead of substring matching, against a live AxonFlow
+enterprise agent, with NO mocks.
+
+Background: every agent error envelope carries a literal `"blocked"` JSON key —
+a tenant-mismatch rejection is `{"success":false,"error":"Tenant mismatch",
+"blocked":false}` — so `handleErrorResponse`'s old
+`body.contains("policy") || body.contains("blocked")` heuristic misclassified
+EVERY 403 authorization rejection as `PolicyViolationException`. Since the
+documented caller pattern treats a policy block as an expected, non-fatal
+outcome, real auth failures (wrong `AXONFLOW_CLIENT_ID`/user-token tenant
+pairing) were silently swallowed with exit 0. Found by the #2861
+release-readiness smoke of `examples/basic`.
+
+The fix parses the JSON body: a present `blocked` boolean is authoritative
+(`true` → `PolicyViolationException`, `false` → `AuthenticationException`);
+only unparseable or `blocked`-less bodies fall back to the policy-phrase
+heuristic (`policy` / `block_reason`, no longer the bare `blocked` key).
+
+This test asserts both directions through the SDK's real public surface
+(`proxyLLMCall`):
+
+1. **Tenant mismatch → `AuthenticationException`.** A valid JWT for a
+   different tenant than the client identity draws the agent's 403
+   `"blocked":false` envelope and must NOT surface as a policy violation.
+2. **Genuine block → `PolicyViolationException`.** A stacked-SQLi query
+   (`sys_sqli_stacked_drop`, `"blocked":true`) still surfaces as a policy
+   violation.
+
+## Run
+
+```bash
+# from the SDK root, against a live enterprise stack
+source /tmp/axonflow-e2e-env.sh          # AXONFLOW_CLIENT_ID/SECRET, endpoint
+export AXONFLOW_USER_TOKEN=...           # JWT, tenant matches AXONFLOW_CLIENT_ID
+export AXONFLOW_MISMATCHED_USER_TOKEN=...# JWT for a DIFFERENT tenant
+                                         # (platform repo: scripts/generate-jwt.sh --tenant-id <other>)
+
+mvn install -DskipTests
+mvn -q dependency:build-classpath -Dmdep.outputFile=/tmp/cp.txt
+SDK_JAR=$(ls target/axonflow-sdk-*.jar | grep -v sources | grep -v javadoc | head -1)
+java -cp "$SDK_JAR:$(cat /tmp/cp.txt)" \
+  runtime-e2e/error_classification_403/ErrorClassification403Test.java
+```
+
+Expected output:
+
+```
+PASS [tenant-mismatch-403] AuthenticationException: ... Tenant mismatch ...
+PASS [policy-block-403] PolicyViolationException: ... stacked DROP TABLE ...
+RESULT: PASS (2/2)
+```

--- a/src/main/java/com/getaxonflow/sdk/AxonFlow.java
+++ b/src/main/java/com/getaxonflow/sdk/AxonFlow.java
@@ -4248,8 +4248,12 @@ public final class AxonFlow implements Closeable {
         // Budget exceeded - treat similarly to 403 policy violation
         throw new PolicyViolationException(errorMessage);
       case 403:
-        // Check if this is a policy violation
-        if (body.contains("policy") || body.contains("blocked")) {
+        // A 403 is a policy violation only when the body actually signals a
+        // block. Every agent error envelope carries a literal "blocked" key
+        // (e.g. {"success":false,"error":"Tenant mismatch","blocked":false}),
+        // so the old substring heuristic misclassified 403 auth rejections
+        // as policy violations.
+        if (isPolicyBlockBody(body)) {
           throw new PolicyViolationException(errorMessage);
         }
         throw new AuthenticationException(errorMessage, 403);
@@ -4263,6 +4267,32 @@ public final class AxonFlow implements Closeable {
       default:
         throw new AxonFlowException(errorMessage, code, null);
     }
+  }
+
+  /**
+   * Decides whether a 403 error body signals a genuine policy block.
+   *
+   * <p>Parses the JSON envelope and reads the {@code blocked} boolean. When the field is present it
+   * is authoritative: {@code true} means a policy block ({@link PolicyViolationException}), {@code
+   * false} means the 403 is an authorization rejection (e.g. tenant mismatch) even though the raw
+   * body contains the literal substring {@code "blocked"}. Only when the body is not parseable
+   * JSON, or carries no {@code blocked} boolean, does this fall back to the legacy policy-phrase
+   * heuristic (for older agents whose error envelopes predate the field).
+   */
+  private boolean isPolicyBlockBody(String body) {
+    if (body == null || body.isEmpty()) {
+      return false;
+    }
+    try {
+      JsonNode node = objectMapper.readTree(body);
+      JsonNode blocked = node.get("blocked");
+      if (blocked != null && blocked.isBoolean()) {
+        return blocked.asBoolean();
+      }
+    } catch (JsonProcessingException e) {
+      // Not JSON — fall through to the phrase heuristic.
+    }
+    return body.contains("policy") || body.contains("block_reason");
   }
 
   private String extractErrorMessage(String body, String defaultMessage) {

--- a/src/test/java/com/getaxonflow/sdk/AxonFlowTest.java
+++ b/src/test/java/com/getaxonflow/sdk/AxonFlowTest.java
@@ -1061,6 +1061,67 @@ class AxonFlowTest {
   }
 
   @Test
+  @DisplayName("403 with blocked:false is an auth rejection, not a policy block")
+  void shouldHandle403BlockedFalseAsAuthRejection() {
+    // Exact live agent envelope for a tenant-mismatch rejection. The body
+    // carries a literal "blocked":false key, which the old substring
+    // heuristic misread as a policy block.
+    stubFor(
+        get(urlEqualTo("/health"))
+            .willReturn(
+                aResponse()
+                    .withStatus(403)
+                    .withBody(
+                        "{\"success\":false,\"error\":\"Tenant mismatch\",\"blocked\":false}")));
+
+    assertThatThrownBy(() -> axonflow.healthCheck())
+        .isInstanceOf(AuthenticationException.class)
+        .isNotInstanceOf(PolicyViolationException.class)
+        .hasMessageContaining("Tenant mismatch");
+  }
+
+  @Test
+  @DisplayName("403 with blocked:true is a policy block")
+  void shouldHandle403BlockedTrueAsPolicyViolation() {
+    // Real policy-block envelope shape from the agent.
+    stubFor(
+        get(urlEqualTo("/health"))
+            .willReturn(
+                aResponse()
+                    .withStatus(403)
+                    .withBody(
+                        "{\"success\":false,\"blocked\":true,"
+                            + "\"block_reason\":\"Detects stacked DROP TABLE/DATABASE"
+                            + " statement\"}")));
+
+    assertThatThrownBy(() -> axonflow.healthCheck())
+        .isInstanceOf(PolicyViolationException.class)
+        .hasMessageContaining("Detects stacked DROP TABLE/DATABASE statement");
+  }
+
+  @Test
+  @DisplayName("403 with unparseable body falls back to the policy-phrase heuristic")
+  void shouldHandle403UnparseableBodyFallback() {
+    stubFor(
+        get(urlEqualTo("/health"))
+            .willReturn(aResponse().withStatus(403).withBody("policy violation upstream")));
+
+    assertThatThrownBy(() -> axonflow.healthCheck()).isInstanceOf(PolicyViolationException.class);
+  }
+
+  @Test
+  @DisplayName("403 with unparseable non-policy body is an auth rejection")
+  void shouldHandle403UnparseableNonPolicyBody() {
+    stubFor(
+        get(urlEqualTo("/health"))
+            .willReturn(aResponse().withStatus(403).withBody("forbidden by proxy")));
+
+    assertThatThrownBy(() -> axonflow.healthCheck())
+        .isInstanceOf(AuthenticationException.class)
+        .isNotInstanceOf(PolicyViolationException.class);
+  }
+
+  @Test
   @DisplayName("should handle 429 Rate Limit")
   void shouldHandle429() {
     stubFor(


### PR DESCRIPTION
Release-blocking library fix from the getaxonflow/axonflow-enterprise#2861 release-readiness gate.

## Bug

Every agent error envelope carries a literal `"blocked"` JSON key - a tenant-mismatch rejection is:

```json
{"success":false,"error":"Tenant mismatch","blocked":false}   // HTTP 403
```

so `handleErrorResponse`'s substring heuristic

```java
case 403:
  if (body.contains("policy") || body.contains("blocked")) {
    throw new PolicyViolationException(errorMessage);
  }
```

classified **every** 403 authorization rejection as `PolicyViolationException`. Callers following the documented pattern (policy block = expected, non-fatal outcome) silently swallowed real auth failures with exit 0 - exactly how `examples/basic` passed the smoke with a wrong client-id/user-token tenant pairing.

## Fix

The 403 branch parses the JSON body (Jackson, already in use) and treats a present `blocked` boolean as **authoritative**:

- `"blocked":true` -> `PolicyViolationException`
- `"blocked":false` -> `AuthenticationException` (HTTP 403)
- unparseable body, or no `blocked` boolean -> legacy policy-phrase fallback (`policy` / `block_reason`; the bare `blocked` substring no longer counts)

Audited the rest of the method: this was the only substring-classification site - 401 always maps to `AuthenticationException`; 402/409/429/408/504 key on status code alone.

## Tests

- Unit (WireMock): exact live tenant-mismatch envelope -> `AuthenticationException` with message intact; `blocked:true` envelope -> `PolicyViolationException`; unparseable-body fallback in both directions.
- New live-stack leg `runtime-e2e/error_classification_403/` (no skip hatch) asserting both directions through `proxyLLMCall`.

## Live runtime-e2e evidence (enterprise stack, platform v9.6.1, agent :8080, original pre-rebase round)

Against this fix:

```
PASS [tenant-mismatch-403] AuthenticationException: Tenant mismatch
PASS [policy-block-403] PolicyViolationException: Request blocked by policy: Detects stacked DROP TABLE/DATABASE statement
RESULT: PASS (2/2)
EXIT=0
```

Same leg against the released **8.5.1** jar (proves the bug + the leg's sensitivity):

```
FAIL: REGRESSION: tenant-mismatch 403 classified as PolicyViolationException (Request blocked by policy: Tenant mismatch) - the "blocked":false envelope must map to AuthenticationException
EXIT=1
```

## Rebase note (2026-08-03, backlog clearance)

Rebased onto main after the 9.0.0 release, #203 (jackson 2.22.1) and #196 (example pins to published 9.0.0). The original 8.5.2 release prep no longer applies and was dropped in the rebase:

- `pom.xml` stays at main's 9.0.0 - versioning belongs to the next release cut (published 9.0.0 does NOT contain this fix; per the semver policy the operator decides the next version, noting this changes the exception type thrown for 403 auth rejections).
- Example pom pins stay at #196's published 9.0.0 (they pin published artifacts; pinning an unpublished version would break `mvn package` for users).
- The CHANGELOG entry now sits under `[Unreleased]` `### Fixed` instead of a `[8.5.2]` heading.

The library fix, unit tests and runtime-e2e leg are unchanged from the reviewed diff.

Refs getaxonflow/axonflow-enterprise#2861.
