### PR TITLE
docs(runtime-e2e): fix stale caller_name_audit prerequisite note

### DIFF
--- a/runtime-e2e/caller_name_audit/README.md
+++ b/runtime-e2e/caller_name_audit/README.md
@@ -29,17 +29,16 @@ authenticated with the identical Basic-auth credentials the SDK's own
 transport sent for the write — the same pattern
 `runtime-e2e/decision_context_transfer_basis` uses for `/api/v1/decide`.
 
-## Prerequisite: platform support is not yet on `main`
+## Platform support
 
-`caller_name` support (axonflow-enterprise#2953) is implemented but, as of
-this writing, still an open PR on the `feat/2912-caller-name-tool-type-deprecation`
-branch — not yet merged to `axonflow-enterprise` main. Against a stack built
-from `axonflow-enterprise` main, this test will FAIL (the polling loop in
-`fetchPolicyDetails` times out waiting for `policy_details.caller_name`,
-which the server doesn't write yet) — that's not a bug in this test, it
-means the platform side isn't deployed on whatever stack you're pointed at.
-Point your local `axonflow-enterprise` checkout at that branch (or a later
-commit that includes it) before running this test.
+`caller_name` support (axonflow-enterprise#2953) has merged to
+`axonflow-enterprise` main and shipped in v9.11.0 — any stack built from
+current `axonflow-enterprise` main (or later) has it. That same merge folded
+in #2903: when neither `callerName` nor the legacy `toolType` is supplied,
+`policy_details.caller_name` now defaults to `"unknown"` (previously
+`"claude_code"`). This test doesn't assert on that no-input default case, so
+it is unaffected either way — but if you add a fourth scenario for it, expect
+`"unknown"` against current `axonflow-enterprise` main.
 
 ## Run
 


### PR DESCRIPTION
## Summary

Small follow-up to #199 (`AuditToolCallRequest.callerName`, getaxonflow/axonflow-enterprise#2912).

- `axonflow-enterprise#2953` (the platform side: `caller_name` + deprecated `tool_type` fallback) has since **merged to `axonflow-enterprise` main and shipped in v9.11.0**. `runtime-e2e/caller_name_audit/README.md` still had a "Prerequisite: platform support is not yet on `main`" section claiming the test would fail against `axonflow-enterprise` main pending that PR — that's now stale. Replaced it with a short "Platform support" note pointing at the current state.
- Also calls out that `axonflow-enterprise#2903` (the no-input default, `"claude_code"` → `"unknown"`) was folded into that same #2953 merge. `runtime-e2e/caller_name_audit/CallerNameAuditTest.java` doesn't assert on the neither-`callerName`-nor-`toolType`-supplied case at all (it only covers `callerName` alone, legacy `toolType` alone, and both together), so this default-value change doesn't require any test code change — only the doc correction.
- No SDK field/method code changes — `callerName`/`toolType` were already independent fields on `AuditToolCallRequest` from #199.

## Test plan

- [x] `runtime-e2e/caller_name_audit/CallerNameAuditTest.java` rerun against a freshly built, isolated Community-mode stack (agent + orchestrator + postgres + redis) built from `axonflow-enterprise`'s actual current merged `main` (confirmed `v9.11.0` via `/health` on both services, not the old unmerged branch): `RESULT: PASS (4/4)` — `callerName` alone, legacy `toolType` alone (fallback), and both together (callerName wins) all resolve correctly in `policy_details.caller_name`, with the legacy `tool_type` key absent from new rows.
- [x] `./mvnw verify` — 1325 surefire tests + 12 failsafe tests, 0 failures, 0 errors.
- [x] `scripts/wire_shape/validate.py` run against the real pinned `getaxonflow/axonflow` OpenAPI specs (`docs/api/*.yaml` @ the SHA pinned in `tests/fixtures/wire-shape-baseline.json`) — clean: `78` validated pairs, `0` drift outside the existing baseline.