### PR TITLE
docs: Runtime Control Demo v2 link (2.5 min)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A deployed AxonFlow platform (self-hosted or cloud) is required for end-to-end A
 Three short videos covering different angles of the platform:
 
 - **[Community Quickstart Demo (Code + Terminal, 2.5 min)](https://youtu.be/BSqU1z0xxCo)** — governed calls, PII block, Gateway Mode with LangChain/CrewAI, and MAP from YAML
-- **[Runtime Control Demo (Portal + Workflow, 3 min)](https://youtu.be/6UatGpn7KwE)** — approvals, retry safety, execution state, and the audit viewer
+- **[Runtime Control Demo (Portal + Workflow, 2.5 min)](https://youtu.be/sRTv2uF0sxY)** — approvals, retry safety, execution state, and the audit viewer
 - **[Architecture Deep Dive (12 min)](https://youtu.be/Q2CZ1qnquhg)** — how the control plane works, policy enforcement flow, and multi-agent planning
 
 ## Requirements


### PR DESCRIPTION
Swaps the Runtime Control Demo YouTube link in the README to the v2 recording (plain-language narration, 2.5 min); updates the stated duration.