### PR TITLE
chore(release): v9.1.0 [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.1.0] - 2026-08-04
+
 ### Added
 
 - masfeat real wire mapping (#3254 pin-advance batch). `RegistrySummary`

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.getaxonflow</groupId>
     <artifactId>axonflow-sdk</artifactId>
-    <version>9.0.0</version>
+    <version>9.1.0</version>
     <packaging>jar</packaging>
 
     <name>AxonFlow Java SDK</name>


### PR DESCRIPTION
## Release v9.1.0

This is a version-bump + CHANGELOG release PR only. No code changes here - the entire 9.1.0 payload is already merged to main across the #3254 pin-advance batch and the caller_name work:

- **Additive audit read-model wire fields.** `policy_decision`, `policy_details`, `response_time_ms` on the audit read model, and `action` on audit search. `request_type` is deprecated (never read on the 9.x line). All additive and absence-tolerant.
- **masfeat/OJK model extension** (#3254 pin-advance batch). Real wire fields added; the never-served fiction fields deprecated. No field removed.
- **OpenAPI spec pin advanced to community v9.13.0.**

No field or public API name was removed, so this is a proper **MINOR** (fields added, some deprecated). Platform v9.14.0 is released and `/health` advertises SDK 9.1.0, so this must ship.

The CHANGELOG `[Unreleased]` section was moved wholesale under a new `## [9.1.0] - 2026-08-04` header, leaving a fresh empty `[Unreleased]` above it. The version-alignment gate and the release preflight both pass locally against 9.1.0.

### Version file bumped
- `pom.xml` project `<version>` -> `9.1.0` (single-jar artifact; the `examples/*` poms are standalone consumers pinning the published dependency and are intentionally left at 9.0.0 until 9.1.0 is on Maven Central)

### Verification
- `mvn -q -DskipTests package` clean; built `target/axonflow-sdk-9.1.0.jar` (+ sources + javadoc)
- `validate-version-alignment.sh` passes (pom.xml == CHANGELOG 9.1.0)

### After merge (master runs the tag; this triggers the **Maven Central** publish)
```
git tag v9.1.0 <merge-commit> && git push origin v9.1.0
```

## Skip-runtime-e2e justification

This is a mechanical release version bump: it changes only the version file(s) and the CHANGELOG (retitling the Unreleased section to [9.1.0]). No runtime surface changes. The code shipped in 9.1.0 (the additive audit read-model wire fields, the masfeat/OJK model extension, and the OpenAPI spec pin) landed in prior PRs that each exercised the runtime-e2e suite; a version stamp has no new user-facing behavior to demonstrate. Skip applied under the v9.14.0 release-train execution.