### PR TITLE
[skip-runtime-e2e] examples: add planning and connectors examples

### DIFF
--- a/examples/connectors/pom.xml
+++ b/examples/connectors/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.getaxonflow.examples</groupId>
+    <artifactId>connectors</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>AxonFlow Java SDK — Connectors Example</name>
+    <description>
+        Minimal read-only example exercising listConnectors() against
+        a running AxonFlow agent.
+    </description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.getaxonflow</groupId>
+            <artifactId>axonflow-sdk</artifactId>
+            <version>9.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.getaxonflow.examples.Connectors</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/connectors/src/main/java/com/getaxonflow/examples/Connectors.java
+++ b/examples/connectors/src/main/java/com/getaxonflow/examples/Connectors.java
@@ -1,0 +1,49 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: Apache-2.0
+//
+// Minimal read-only AxonFlow Java SDK connectors example.
+//
+// Run from this directory:
+//
+//   mvn -q compile exec:java
+package com.getaxonflow.examples;
+
+import com.getaxonflow.sdk.AxonFlow;
+import com.getaxonflow.sdk.AxonFlowConfig;
+import com.getaxonflow.sdk.types.ConnectorInfo;
+
+import java.util.List;
+
+public class Connectors {
+
+    public static void main(String[] args) {
+        String endpoint = envOrDefault("AXONFLOW_AGENT_URL", "http://localhost:8080");
+        String clientId = envOrDefault("AXONFLOW_CLIENT_ID", "community");
+        String clientSecret = envOrDefault("AXONFLOW_CLIENT_SECRET", "");
+
+        try (AxonFlow client =
+                AxonFlow.create(
+                        AxonFlowConfig.builder()
+                                .endpoint(endpoint)
+                                .clientId(clientId)
+                                .clientSecret(clientSecret)
+                                .build())) {
+            List<ConnectorInfo> connectors = client.listConnectors();
+            System.out.printf("Found %d connectors%n", connectors.size());
+            for (ConnectorInfo connector : connectors) {
+                System.out.printf(
+                        "- id=%s name=%s type=%s version=%s installed=%s%n",
+                        connector.getId(),
+                        connector.getName(),
+                        connector.getType(),
+                        connector.getVersion(),
+                        connector.isInstalled());
+            }
+        }
+    }
+
+    private static String envOrDefault(String name, String fallback) {
+        String value = System.getenv(name);
+        return value == null || value.isEmpty() ? fallback : value;
+    }
+}

--- a/examples/planning/pom.xml
+++ b/examples/planning/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.getaxonflow.examples</groupId>
+    <artifactId>planning</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>AxonFlow Java SDK — Planning Example</name>
+    <description>
+        Minimal example exercising generatePlan() + executePlan() against
+        a running AxonFlow agent.
+    </description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.getaxonflow</groupId>
+            <artifactId>axonflow-sdk</artifactId>
+            <version>9.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.getaxonflow.examples.Planning</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/planning/src/main/java/com/getaxonflow/examples/Planning.java
+++ b/examples/planning/src/main/java/com/getaxonflow/examples/Planning.java
@@ -1,0 +1,54 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: Apache-2.0
+//
+// Minimal AxonFlow Java SDK planning example.
+//
+// This example requires a local AxonFlow stack with an LLM provider configured.
+//
+// Run from this directory:
+//
+//   mvn -q compile exec:java
+package com.getaxonflow.examples;
+
+import com.getaxonflow.sdk.AxonFlow;
+import com.getaxonflow.sdk.AxonFlowConfig;
+import com.getaxonflow.sdk.types.PlanRequest;
+import com.getaxonflow.sdk.types.PlanResponse;
+
+public class Planning {
+
+    public static void main(String[] args) {
+        String endpoint = envOrDefault("AXONFLOW_AGENT_URL", "http://localhost:8080");
+        String clientId = envOrDefault("AXONFLOW_CLIENT_ID", "community");
+        String clientSecret = envOrDefault("AXONFLOW_CLIENT_SECRET", "");
+
+        try (AxonFlow client =
+                AxonFlow.create(
+                        AxonFlowConfig.builder()
+                                .endpoint(endpoint)
+                                .clientId(clientId)
+                                .clientSecret(clientSecret)
+                                .build())) {
+            PlanRequest request =
+                    PlanRequest.builder()
+                            .objective("Research a topic and summarize the key findings")
+                            .build();
+
+            System.out.println("Generating plan...");
+            PlanResponse plan = client.generatePlan(request);
+            System.out.println("Plan generated: " + plan.getPlanId());
+
+            System.out.println("Executing plan...");
+            PlanResponse result = client.executePlan(plan.getPlanId());
+            System.out.println("Plan execution status: " + result.getStatus());
+            if (result.getResult() != null) {
+                System.out.println("Result: " + result.getResult());
+            }
+        }
+    }
+
+    private static String envOrDefault(String name, String fallback) {
+        String value = System.getenv(name);
+        return value == null || value.isEmpty() ? fallback : value;
+    }
+}


### PR DESCRIPTION
## Summary
- add a minimal planning example using `generatePlan()` and `executePlan()`
- add a read-only connectors example using `listConnectors()`
- follow the existing Java example layout and Maven setup
## Testing
- both example projects compile successfully
- full Maven `verify` passes locally
- live execution was not run because no local AxonFlow community stack was available; the planning example also requires an LLM provider as documented in the source
## Skip-runtime-e2e justification
This PR only adds the two example directories requested in #146. The issue explicitly scopes `integration.yml` wiring as optional because the planning example requires an LLM provider that may not be available in CI. No SDK runtime behavior is changed.
Closes #146
